### PR TITLE
Add manifest merge logic for applying fs diffs

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -1,0 +1,96 @@
+package continuity
+
+import (
+	"sort"
+	"strings"
+)
+
+// MergeManifests merges a manifest onto another manifest. Only
+// the diff manifest should contain whiteout information.
+func MergeManifests(manifest, diff *Manifest) *Manifest {
+	r1 := manifest.Resources
+	sort.Sort(ByPath(r1))
+	r2 := diff.Resources
+	sort.Sort(ByPath(r2))
+	return mergeResources(r1, r2)
+}
+
+// mergeResources merges two ordered set of resources into manifest
+// using the provided whiteout and comparison function.
+// TODO(dmcgowan): Handle handlinks
+func mergeResources(r1, r2 []Resource) *Manifest {
+	result := make([]Resource, 0, len(r1))
+
+	i1 := 0
+	i2 := 0
+
+	for i1 < len(r1) && i2 < len(r2) {
+		p1 := r1[i1].Path()
+		p2 := r2[i2].Path()
+
+		switch {
+		case p1 < p2:
+			result = append(result, r1[i1])
+			i1++
+		case p1 == p2:
+			// p1 will be replaced by p2
+			i1++
+			fallthrough
+		default:
+			var skipPath string
+			switch resource := r2[i2].(type) {
+			case Whiteout:
+				skipPath = asDir(resource.Path())
+			case Directory:
+				if resource.IsOpaque() {
+					skipPath = asDir(resource.Path())
+					result = append(result, Resource(removeOpaqueness(resource)))
+				} else {
+					result = append(result, r2[i2])
+				}
+			default:
+				// Not a directory, skip any files under path (replaces directory)
+				skipPath = asDir(resource.Path())
+				result = append(result, r2[i2])
+			}
+			if skipPath != "" {
+				for i1 < len(r1) && strings.HasPrefix(r1[i1].Path(), skipPath) {
+					// Ignore resource in opaque or deleted directory
+					i1++
+				}
+			}
+			i2++
+		}
+	}
+
+	for i1 < len(r1) {
+		result = append(result, r1[i1])
+		i1++
+	}
+	for i2 < len(r2) {
+		switch resource := r2[i2].(type) {
+		case Whiteout:
+			// Ignore, no more files to whiteout
+		case Directory:
+			if resource.IsOpaque() {
+				result = append(result, Resource(removeOpaqueness(resource)))
+			} else {
+				result = append(result, r2[i2])
+			}
+		default:
+			result = append(result, r2[i2])
+		}
+		i2++
+	}
+
+	return &Manifest{
+		Resources: result,
+	}
+}
+
+func asDir(name string) string {
+	if name == "" || name[len(name)-1] != '/' {
+		return name + "/"
+	}
+	return name
+}

--- a/merge_test.go
+++ b/merge_test.go
@@ -1,0 +1,143 @@
+package continuity
+
+import (
+	"testing"
+
+	"github.com/docker/distribution/digest"
+)
+
+func randomDigest(size int) digest.Digest {
+	d := make([]byte, size)
+	randomBytes(d)
+	return digest.FromBytes(d)
+}
+
+func TestMerge(t *testing.T) {
+	layer1 := []dresource{
+		{
+			kind: rdirectory,
+			path: "a",
+			mode: 0755,
+		},
+		{
+			kind:   rfile,
+			size:   4085,
+			digest: randomDigest(4085),
+			path:   "a/f1",
+			mode:   0600,
+		},
+		{
+			kind:   rfile,
+			size:   1023,
+			digest: randomDigest(1023),
+			path:   "a/f2",
+			mode:   0600,
+		},
+		{
+			kind: rdirectory,
+			path: "b",
+			mode: 0755,
+		},
+		{
+			kind:   rfile,
+			size:   1023,
+			digest: randomDigest(1023),
+			path:   "b/hidden",
+			mode:   0600,
+		},
+		{
+			kind: rdirectory,
+			path: "c",
+			mode: 0755,
+		},
+		{
+			path: "c/f1",
+			mode: 0600,
+		},
+	}
+	layer2 := []dresource{
+		{
+			kind: rdirectory,
+			path: "a",
+			mode: 0755,
+		},
+		{
+			kind:   rfile,
+			size:   1022,
+			digest: randomDigest(1022),
+			path:   "a/f2",
+			mode:   0644,
+		},
+		{
+			kind:   rfile,
+			size:   234,
+			digest: randomDigest(234),
+			path:   "a/f3",
+			mode:   0600,
+		},
+		{
+			kind:   rdirectory,
+			path:   "b",
+			mode:   0755,
+			opaque: true,
+		},
+		{
+			kind:   rfile,
+			size:   1023,
+			digest: randomDigest(1023),
+			path:   "b/nothidden",
+			mode:   0600,
+		},
+		{
+			kind: rwhiteout,
+			path: "c",
+		},
+	}
+	result := []dresource{
+		layer2[0],
+		layer1[1],
+		layer2[1],
+		layer2[2],
+		{
+			kind: rdirectory,
+			path: "b",
+			mode: 0755,
+		},
+		layer2[4],
+	}
+
+	checkMerge(t, layer1, layer2, result)
+}
+
+func checkMerge(t *testing.T, layer1, layer2, result []dresource) {
+	r1, err := expectedResourceList(layer1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2, err := expectedResourceList(layer2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, err := expectedResourceList(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mm := MergeManifests(&Manifest{Resources: r1}, &Manifest{Resources: r2})
+
+	diff := diffResourceList(expected, mm.Resources)
+	if diff.HasDiff() {
+		t.Log("Resource list difference")
+		for _, a := range diff.Additions {
+			t.Logf("Unexpected resource: %#v", a)
+		}
+		for _, d := range diff.Deletions {
+			t.Logf("Missing resource: %#v", d)
+		}
+		for _, u := range diff.Updates {
+			t.Logf("Changed resource:\n\tExpected: %#v\n\tActual:   %#v", u.Original, u.Updated)
+		}
+
+		t.FailNow()
+	}
+}

--- a/proto/manifest.pb.go
+++ b/proto/manifest.pb.go
@@ -77,6 +77,10 @@ type Resource struct {
 	Xattr map[string][]byte `protobuf:"bytes,12,rep,name=xattr" json:"xattr,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Ads stores one or more alternate data streams for the target resource.
 	Ads map[string][]byte `protobuf:"bytes,13,rep,name=ads" json:"ads,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	// Whiteout indicates this resource should not be applied and discard any
+	// resources with the same path previously encountered. If this resource
+	// is a directory, the directory should be created as opaque.
+	Whiteout bool `protobuf:"varint,14,opt,name=whiteout" json:"whiteout,omitempty"`
 }
 
 func (m *Resource) Reset()         { *m = Resource{} }

--- a/proto/manifest.proto
+++ b/proto/manifest.proto
@@ -74,4 +74,8 @@ message Resource {
     // Ads stores one or more alternate data streams for the target resource.
     map<string, bytes> ads = 13;
 
+    // Whiteout indicates this resource should not be applied and discard any
+    // resources with the same path previously encountered. If this resource
+    // is a directory, the directory should be created as opaque.
+    bool whiteout = 14;
 }

--- a/resource_test.go
+++ b/resource_test.go
@@ -1,0 +1,156 @@
+package continuity
+
+type resourceUpdate struct {
+	Original Resource
+	Updated  Resource
+}
+
+type resourceListDifference struct {
+	Additions []Resource
+	Deletions []Resource
+	Updates   []resourceUpdate
+}
+
+func (l resourceListDifference) HasDiff() bool {
+	return len(l.Additions) > 0 || len(l.Deletions) > 0 || len(l.Updates) > 0
+}
+
+// diffManifest compares two resource lists and returns the list
+// of adds updates and deletes, resource lists are not reordered
+// before doing difference.
+func diffResourceList(r1, r2 []Resource) resourceListDifference {
+	i1 := 0
+	i2 := 0
+	var d resourceListDifference
+
+	for i1 < len(r1) && i2 < len(r2) {
+		p1 := r1[i1].Path()
+		p2 := r2[i2].Path()
+		switch {
+		case p1 < p2:
+			d.Deletions = append(d.Deletions, r1[i1])
+			i1++
+		case p1 == p2:
+			if !compareResource(r1[i1], r2[i2]) {
+				d.Updates = append(d.Updates, resourceUpdate{
+					Original: r1[i1],
+					Updated:  r2[i2],
+				})
+			}
+			i1++
+			i2++
+		case p1 > p2:
+			d.Additions = append(d.Additions, r2[i2])
+			i2++
+		}
+	}
+
+	for i1 < len(r1) {
+		d.Deletions = append(d.Deletions, r1[i1])
+		i1++
+
+	}
+	for i2 < len(r2) {
+		d.Additions = append(d.Additions, r2[i2])
+		i2++
+	}
+
+	return d
+}
+
+func compareResource(r1, r2 Resource) bool {
+	if r1.Path() != r2.Path() {
+		return false
+	}
+	if r1.Mode() != r2.Mode() {
+		return false
+	}
+	if r1.UID() != r2.UID() {
+		return false
+	}
+	if r1.GID() != r2.GID() {
+		return false
+	}
+
+	// TODO(dmcgowan): Check if is XAttrer
+
+	switch t1 := r1.(type) {
+	case RegularFile:
+		t2, ok := r2.(RegularFile)
+		if !ok {
+			return false
+		}
+		return compareRegularFile(t1, t2)
+	case Directory:
+		t2, ok := r2.(Directory)
+		if !ok {
+			return false
+		}
+		return compareDirectory(t1, t2)
+	case SymLink:
+		t2, ok := r2.(SymLink)
+		if !ok {
+			return false
+		}
+		return compareSymLink(t1, t2)
+	case NamedPipe:
+		t2, ok := r2.(NamedPipe)
+		if !ok {
+			return false
+		}
+		return compareNamedPipe(t1, t2)
+	case Device:
+		t2, ok := r2.(Device)
+		if !ok {
+			return false
+		}
+		return compareDevice(t1, t2)
+	default:
+		// TODO(dmcgowan): Should this panic?
+		return r1 == r2
+	}
+}
+
+func compareRegularFile(r1, r2 RegularFile) bool {
+	if r1.Size() != r2.Size() {
+		return false
+	}
+	p1 := r1.Paths()
+	p2 := r2.Paths()
+	if len(p1) != len(p2) {
+		return false
+	}
+	for i := range p1 {
+		if p1[i] != p2[i] {
+			return false
+		}
+	}
+	d1 := r1.Digests()
+	d2 := r2.Digests()
+	if len(d1) != len(d2) {
+		return false
+	}
+	for i := range d1 {
+		if d1[i] != d2[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func compareSymLink(r1, r2 SymLink) bool {
+	return r1.Target() == r2.Target()
+}
+
+func compareDirectory(r1, r2 Directory) bool {
+	return true
+}
+
+func compareNamedPipe(r1, r2 NamedPipe) bool {
+	return true
+}
+
+func compareDevice(r1, r2 Device) bool {
+	return r1.Major() == r2.Major() && r1.Minor() == r2.Minor()
+}


### PR DESCRIPTION
Allow creating manifest directly from an overlay or aufs diff directory and merging on top of another manifest.

This is an initial implementation, further optimization and unit testing should be considered for wider use. The most useful application could be turning Docker image layers directly into a continuity manifest for an image (after converting each tar into manifest).
