### PR TITLE
build: support --format (pb and json)

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"io/ioutil"
 	"log"
 
 	"github.com/containerd/continuity"
@@ -14,14 +13,9 @@ var ApplyCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		root, path := args[0], args[1]
 
-		p, err := ioutil.ReadFile(path)
+		m, err := readManifest(path)
 		if err != nil {
-			log.Fatalf("error reading manifest: %v", err)
-		}
-
-		m, err := continuity.Unmarshal(p)
-		if err != nil {
-			log.Fatalf("error unmarshaling manifest: %v", err)
+			log.Fatal(err)
 		}
 
 		ctx, err := continuity.NewContext(root)

--- a/commands/commandsutil.go
+++ b/commands/commandsutil.go
@@ -1,0 +1,22 @@
+package commands
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/continuity"
+)
+
+func readManifest(path string) (*continuity.Manifest, error) {
+	p, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading manifest: %v", err)
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext == ".json" {
+		return continuity.UnmarshalJSON(p)
+	}
+	return continuity.Unmarshal(p)
+}

--- a/commands/mount.go
+++ b/commands/mount.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -30,14 +29,9 @@ var MountCmd = &cobra.Command{
 
 		manifestName := filepath.Base(manifest)
 
-		p, err := ioutil.ReadFile(manifest)
+		m, err := readManifest(manifest)
 		if err != nil {
-			log.Fatalf("error reading manifest: %v", err)
-		}
-
-		m, err := continuity.Unmarshal(p)
-		if err != nil {
-			log.Fatalf("error unmarshaling manifest: %v", err)
+			log.Fatal(err)
 		}
 
 		driver, err := continuity.NewSystemDriver()

--- a/commands/verify.go
+++ b/commands/verify.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"io/ioutil"
 	"log"
 
 	"github.com/containerd/continuity"
@@ -18,14 +17,9 @@ var VerifyCmd = &cobra.Command{
 
 		root, path := args[0], args[1]
 
-		p, err := ioutil.ReadFile(path)
+		m, err := readManifest(path)
 		if err != nil {
-			log.Fatalf("error reading manifest: %v", err)
-		}
-
-		m, err := continuity.Unmarshal(p)
-		if err != nil {
-			log.Fatalf("error unmarshaling manifest: %v", err)
+			log.Fatal(err)
 		}
 
 		ctx, err := continuity.NewContext(root)


### PR DESCRIPTION
This PR implements `continuity build --format`.
Fix #46

e.g.
```console
$ continuity build --format application/vnd.continuity.manifest.v0+json .
$ continuity build --format application/vnd.continuity.manifest.v0+pb .
```

alias:
```console
$ continuity build --format json .
$ continuity build --format pb .
```

The JSON format is implemented using `jsonpb.Marshaller{EnumAsInts: false, EmitDefaults: false, OrigName: false}`.  https://godoc.org/github.com/golang/protobuf/jsonpb#Marshaler

JSON format would be useful when a continuity manifest is included in an OCI image.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
