### PR TITLE
[WIP] Add copy to method to content provider

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,6 +2,7 @@ package continuity
 
 import (
 	"bytes"
+	ctxu "context"
 	"fmt"
 	"io"
 	"log"
@@ -370,7 +371,7 @@ func (c *context) checkoutFile(fp string, rf RegularFile) error {
 		err error
 	)
 	for _, dgst := range rf.Digests() {
-		r, err = c.provider.Reader(dgst)
+		r, err = c.provider.Reader(ctxu.Background(), dgst)
 		if err == nil {
 			break
 		}
@@ -609,7 +610,7 @@ func (c *context) digest(p string) (digest.Digest, error) {
 	}
 	defer f.Close()
 
-	return c.digester.Digest(f)
+	return c.digester.Digest(ctxu.Background(), f)
 }
 
 // resolveXAttrs attempts to resolve the extended attributes for the resource

--- a/copy_linux.go
+++ b/copy_linux.go
@@ -1,0 +1,30 @@
+package continuity
+
+import (
+	"io"
+	"os"
+	"syscall"
+
+	"github.com/stevvooe/continuity/sysx"
+)
+
+type rawFile interface {
+	Fd() uintptr
+
+	// TODO: Add function for getting position of file
+}
+
+func fastCopy(dst *os.File, r io.Reader, size int64) (int64, error) {
+	rf, ok := r.(rawFile)
+	if !ok {
+		return 0, nil
+	}
+
+	// TODO: track offsets and call multiple times for short writes
+	n, err := sysx.CopyFileRange(rf.Fd(), nil, dst.Fd(), nil, int(size), 0)
+	if n == 0 && (err == syscall.ENOSYS || err == syscall.EXDEV) {
+		// System call not supported
+		return 0, nil
+	}
+	return int64(n), err
+}

--- a/copy_unsupported.go
+++ b/copy_unsupported.go
@@ -1,0 +1,12 @@
+// +build !linux
+
+package continuity
+
+import (
+	"io"
+	"os"
+)
+
+func fastCopy(dst *os.File, r io.Reader, size int64) (int64, error) {
+	return 0, nil
+}

--- a/ioutils.go
+++ b/ioutils.go
@@ -14,21 +14,11 @@ func atomicWriteFile(filename string, r io.Reader, rf RegularFile) error {
 	if err != nil {
 		return err
 	}
-	err = os.Chmod(f.Name(), rf.Mode())
-	if err != nil {
+	if err := copyFileContent(f, r, rf.Size()); err != nil {
 		f.Close()
 		return err
 	}
-	n, err := io.Copy(f, r)
-	if err == nil && n < rf.Size() {
-		f.Close()
-		return io.ErrShortWrite
-	}
-	if err != nil {
-		f.Close()
-		return err
-	}
-	if err := f.Sync(); err != nil {
+	if err = os.Chmod(f.Name(), rf.Mode()); err != nil {
 		f.Close()
 		return err
 	}
@@ -36,4 +26,29 @@ func atomicWriteFile(filename string, r io.Reader, rf RegularFile) error {
 		return err
 	}
 	return os.Rename(f.Name(), filename)
+}
+
+func copyFileContent(dst *os.File, r io.Reader, size int64) error {
+	n, err := fastCopy(dst, r, size)
+	if err != nil {
+		return err
+	}
+	if n < size {
+		if n > 0 {
+			return io.ErrShortWrite
+		}
+		n, err = io.Copy(dst, r)
+		if err == nil && n < size {
+			return io.ErrShortWrite
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := dst.Sync(); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
Allows content provider to optimize creation of files directly from the blobstore. This could be used to call copy file range on file systems which support it.