### PR TITLE
Provide a constant for ENODATA

### DIFF
--- a/sysx/nodata_linux.go
+++ b/sysx/nodata_linux.go
@@ -1,0 +1,7 @@
+package sysx
+
+import (
+	"syscall"
+)
+
+const ENODATA = syscall.ENODATA

--- a/sysx/nodata_unix.go
+++ b/sysx/nodata_unix.go
@@ -1,0 +1,9 @@
+// +build darwin freebsd
+
+package sysx
+
+import (
+	"syscall"
+)
+
+const ENODATA = syscall.ENOATTR


### PR DESCRIPTION
There is no real standardisation between Unix versions as to whether
ENODATA or ENOATTR is used, so provide a standard constant in sysx that
can be used by consumers.

Linux returns ENODATA, while FreeBSD and Darwin return ENOATTR; to
confuse things ENODATA is defined on Darwin but is not returned for
extended attributes.

Applications should use `sysx.ENODATA` instead.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>