### PR TITLE
Remove duplicated function declared for darwin

### DIFF
--- a/driver_darwin.go
+++ b/driver_darwin.go
@@ -1,7 +1,0 @@
-package continuity
-
-import "os"
-
-func (d *driver) DeviceInfo(fi os.FileInfo) (maj uint64, min uint64, err error) {
-	return deviceInfo(fi)
-}


### PR DESCRIPTION
Device info is already declared for unix and matches exactly the darwin definition. Continuity building for darwin is currently broken because of this.