### PR TITLE
update to github.com/sirupsen/logrus v1.0.0

### DIFF
--- a/commands/mount.go
+++ b/commands/mount.go
@@ -14,10 +14,10 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/containerd/continuity"
 	"github.com/containerd/continuity/continuityfs"
 	"github.com/containerd/continuity/driver"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 

--- a/continuityfs/fuse.go
+++ b/continuityfs/fuse.go
@@ -12,9 +12,9 @@ import (
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
-	"github.com/Sirupsen/logrus"
 	"github.com/containerd/continuity"
 	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 


### PR DESCRIPTION
Signed-off-by: Andrew Pennebaker <apennebaker@datapipe.com>

Fix some dependencies by updating to latest logrus, now hosted at github.com/sirupsen/logrus.