### PR TITLE
Add solaris build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - TRAVIS_GOOS=windows
   - TRAVIS_GOOS=linux
   - TRAVIS_GOOS=darwin
+  - TRAVIS_GOOS=solaris
 
 script:
 # TODO: vendor
@@ -19,3 +20,4 @@ script:
   - go get -t ./...
   - make build binaries
   - if [ "$GOOS" = "linux" ]; then make vet test; fi
+  - if [ "$GOOS" != "linux" ]; then make test-compile; fi

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ test:
 	@echo "+ $@"
 	@go test ./...
 
+test-compile:
+	@echo "+ $@"
+	@for pkg in $$(go list ./...); do go test -c $$pkg; done
+
 binaries: ${PREFIX}/bin/continuity
 	@echo "+ $@"
 	@if [ x$$GOOS = xwindows ]; then echo "+ continuity -> continuity.exe"; mv ${PREFIX}/bin/continuity ${PREFIX}/bin/continuity.exe; fi

--- a/commands/mount.go
+++ b/commands/mount.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux darwin freebsd
 
 package commands
 

--- a/commands/mount_unsupported.go
+++ b/commands/mount_unsupported.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build windows solaris
 
 package commands
 

--- a/continuityfs/fuse.go
+++ b/continuityfs/fuse.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux darwin freebsd
 
 package continuityfs
 

--- a/continuityfs/provider.go
+++ b/continuityfs/provider.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux darwin freebsd
 
 package continuityfs
 

--- a/devices/devices_dummy.go
+++ b/devices/devices_dummy.go
@@ -1,0 +1,23 @@
+// +build solaris,!cgo
+
+//
+// Implementing the functions below requires cgo support.  Non-cgo stubs
+// versions are defined below to enable cross-compilation of source code
+// that depends on these functions, but the resultant cross-compiled
+// binaries cannot actually be used.  If the stub function(s) below are
+// actually invoked they will cause the calling process to exit.
+//
+
+package devices
+
+func getmajor(dev uint64) uint64 {
+	panic("getmajor() support requires cgo.")
+}
+
+func getminor(dev uint64) uint64 {
+	panic("getminor() support requires cgo.")
+}
+
+func makedev(major int, minor int) int {
+	panic("makedev() support requires cgo.")
+}

--- a/devices/devices_solaris.go
+++ b/devices/devices_solaris.go
@@ -1,0 +1,18 @@
+// +build cgo
+
+package devices
+
+//#include <sys/mkdev.h>
+import "C"
+
+func getmajor(dev uint64) uint64 {
+	return uint64(C.major(C.dev_t(dev)))
+}
+
+func getminor(dev uint64) uint64 {
+	return uint64(C.minor(C.dev_t(dev)))
+}
+
+func makedev(major int, minor int) int {
+	return int(C.makedev(C.major_t(major), C.minor_t(minor)))
+}

--- a/devices/devices_unix.go
+++ b/devices/devices_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd
+// +build linux darwin freebsd solaris
 
 package devices
 

--- a/driver/driver_unix.go
+++ b/driver/driver_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd
+// +build linux darwin freebsd solaris
 
 package driver
 

--- a/hardlinks_unix.go
+++ b/hardlinks_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd
+// +build linux darwin freebsd solaris
 
 package continuity
 

--- a/resource_unix.go
+++ b/resource_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd
+// +build linux darwin freebsd solaris
 
 package continuity
 

--- a/sysx/chmod_solaris.go
+++ b/sysx/chmod_solaris.go
@@ -1,0 +1,11 @@
+package sysx
+
+import "golang.org/x/sys/unix"
+
+const (
+	AtSymlinkNofollow = unix.AT_SYMLINK_NOFOLLOW
+)
+
+func Fchmodat(dirfd int, path string, mode uint32, flags int) error {
+	return unix.Fchmodat(dirfd, path, mode, flags)
+}

--- a/sysx/nodata_solaris.go
+++ b/sysx/nodata_solaris.go
@@ -1,0 +1,8 @@
+package sysx
+
+import (
+	"syscall"
+)
+
+// This should actually be a set that contains ENOENT and EPERM
+const ENODATA = syscall.ENOENT

--- a/sysx/xattr_solaris.go
+++ b/sysx/xattr_solaris.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 )
 
-// Initial stub version for FreeBSD. FreeBSD has a different
+// Initial stub version for Solaris. Solaris has a different
 // syscall API from Darwin and Linux for extended attributes;
 // it is also not widely used. It is not exposed at all by the
 // Go syscall package, so we need to implement directly eventually.
 
-var unsupported = errors.New("extended attributes unsupported on FreeBSD")
+var unsupported = errors.New("extended attributes unsupported on Solaris")

--- a/sysx/xattr_unsupported.go
+++ b/sysx/xattr_unsupported.go
@@ -1,0 +1,44 @@
+// +build freebsd solaris
+
+package sysx
+
+// Listxattr calls syscall listxattr and reads all content
+// and returns a string array
+func Listxattr(path string) ([]string, error) {
+	return []string{}, nil
+}
+
+// Removexattr calls syscall removexattr
+func Removexattr(path string, attr string) (err error) {
+	return unsupported
+}
+
+// Setxattr calls syscall setxattr
+func Setxattr(path string, attr string, data []byte, flags int) (err error) {
+	return unsupported
+}
+
+// Getxattr calls syscall getxattr
+func Getxattr(path, attr string) ([]byte, error) {
+	return []byte{}, unsupported
+}
+
+// LListxattr lists xattrs, not following symlinks
+func LListxattr(path string) ([]string, error) {
+	return []string{}, nil
+}
+
+// LRemovexattr removes an xattr, not following symlinks
+func LRemovexattr(path string, attr string) (err error) {
+	return unsupported
+}
+
+// LSetxattr sets an xattr, not following symlinks
+func LSetxattr(path string, attr string, data []byte, flags int) (err error) {
+	return unsupported
+}
+
+// LGetxattr gets an xattr, not following symlinks
+func LGetxattr(path, attr string) ([]byte, error) {
+	return []byte{}, nil
+}


### PR DESCRIPTION
since the last moby summit i've been working on porting containerd to
solaris.  to do this i need to make changes to this vendored component.

at the summit i was asked to try and err on the side of having multiple
smaller changesets rather than one large changeset.  to that end, this
pull request contains the smallest amount of changes necessary to get
this component to compile on solaris, to cross-compile for solaris on
linux, and to test solaris cross-compilation on linux via travis-ci.

it's worth mentioning that while these these changes allow solaris
cross-compilation on linux, the resultant binary isn't actually usable
on solaris.  this is because compilation of this component on solaris
requires the use of cgo, and we can't cross-compile solaris cgo code on
linux.  I chose to enable cross-compilation (even though the resultant
binary is broken) because that allows us to do testing via travis ci,
similar to what is currently being done for windows.

with these changes the component tests run successfully on solaris.