### PR TITLE
proto: fix typo in comments

### DIFF
--- a/proto/manifest.pb.go
+++ b/proto/manifest.pb.go
@@ -82,9 +82,9 @@ type Resource struct {
 	// Relative links do not start with a slash and are relative to the
 	// resource path.
 	Target string `protobuf:"bytes,9,opt,name=target" json:"target,omitempty"`
-	// Major specifies the major device number for charactor and block devices.
+	// Major specifies the major device number for character and block devices.
 	Major uint64 `protobuf:"varint,10,opt,name=major" json:"major,omitempty"`
-	// Minor specifies the minor device number for charactor and block devices.
+	// Minor specifies the minor device number for character and block devices.
 	Minor uint64 `protobuf:"varint,11,opt,name=minor" json:"minor,omitempty"`
 	// Xattr provides storage for extended attributes for the target resource.
 	Xattr []*XAttr `protobuf:"bytes,12,rep,name=xattr" json:"xattr,omitempty"`

--- a/proto/manifest.proto
+++ b/proto/manifest.proto
@@ -16,7 +16,7 @@ message Resource {
 
     // NOTE(stevvooe): Need to define clear precedence for user/group/uid/gid precedence.
 
-    // Uid specifies the user id for the resource. 
+    // Uid specifies the user id for the resource.
     int64 uid = 2;
 
     // Gid specifies the group id for the resource.
@@ -53,10 +53,10 @@ message Resource {
     // resource path.
     string target = 9;
 
-    // Major specifies the major device number for charactor and block devices.
+    // Major specifies the major device number for character and block devices.
     uint64 major = 10;
 
-    // Minor specifies the minor device number for charactor and block devices.
+    // Minor specifies the minor device number for character and block devices.
     uint64 minor = 11;
 
     // Xattr provides storage for extended attributes for the target resource.


### PR DESCRIPTION
s/charactor/character/ and remove a trailing whitespace.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>