### PR TITLE
sysx: remove unused SYS_COPY_FILE_RANGE definitions

### DIFF
--- a/sysx/sysnum_linux_386.go
+++ b/sysx/sysnum_linux_386.go
@@ -1,7 +1,0 @@
-package sysx
-
-const (
-	// SYS_COPYFILERANGE defined in Kernel 4.5+
-	// Number defined in /usr/include/asm/unistd_32.h
-	SYS_COPY_FILE_RANGE = 377
-)

--- a/sysx/sysnum_linux_amd64.go
+++ b/sysx/sysnum_linux_amd64.go
@@ -1,7 +1,0 @@
-package sysx
-
-const (
-	// SYS_COPYFILERANGE defined in Kernel 4.5+
-	// Number defined in /usr/include/asm/unistd_64.h
-	SYS_COPY_FILE_RANGE = 326
-)

--- a/sysx/sysnum_linux_arm.go
+++ b/sysx/sysnum_linux_arm.go
@@ -1,7 +1,0 @@
-package sysx
-
-const (
-	// SYS_COPY_FILE_RANGE defined in Kernel 4.5+
-	// Number defined in /usr/include/arm-linux-gnueabihf/asm/unistd.h
-	SYS_COPY_FILE_RANGE = 391
-)

--- a/sysx/sysnum_linux_arm64.go
+++ b/sysx/sysnum_linux_arm64.go
@@ -1,7 +1,0 @@
-package sysx
-
-const (
-	// SYS_COPY_FILE_RANGE defined in Kernel 4.5+
-	// Number defined in /usr/include/asm-generic/unistd.h
-	SYS_COPY_FILE_RANGE = 285
-)

--- a/sysx/sysnum_linux_ppc64le.go
+++ b/sysx/sysnum_linux_ppc64le.go
@@ -1,7 +1,0 @@
-package sysx
-
-const (
-	// SYS_COPYFILERANGE defined in Kernel 4.5+
-	// Number defined in /usr/include/asm/unistd_64.h
-	SYS_COPY_FILE_RANGE = 379
-)

--- a/sysx/sysnum_linux_s390x.go
+++ b/sysx/sysnum_linux_s390x.go
@@ -1,7 +1,0 @@
-package sysx
-
-const (
-	// SYS_COPYFILERANGE defined in Kernel 4.5+
-	// Number defined in /usr/include/asm/unistd_64.h
-	SYS_COPY_FILE_RANGE = 375
-)


### PR DESCRIPTION
Since PR #92 removed the custom implementation of CopyFileRange, these
syscall numbers are unused. Remove them.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>