### PR TITLE
Ensure rmdir gets set for every directory

### DIFF
--- a/fs/diff.go
+++ b/fs/diff.go
@@ -273,7 +273,7 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 				if rmdir != "" && strings.HasPrefix(f1.path, rmdir) {
 					f1 = nil
 					continue
-				} else if rmdir == "" && f1.f.IsDir() {
+				} else if f1.f.IsDir() {
 					rmdir = f1.path + string(os.PathSeparator)
 				} else if rmdir != "" {
 					rmdir = ""

--- a/fs/diff_test.go
+++ b/fs/diff_test.go
@@ -56,6 +56,28 @@ func TestSimpleDiff(t *testing.T) {
 	}
 }
 
+func TestNestedDeletion(t *testing.T) {
+	skipDiffTestOnWindows(t)
+	l1 := fstest.Apply(
+		fstest.CreateDir("/d0", 0755),
+		fstest.CreateDir("/d1", 0755),
+		fstest.CreateDir("/d1/d2", 0755),
+		fstest.CreateFile("/d1/d2/f1", []byte("mydomain 10.0.0.1"), 0644),
+	)
+	l2 := fstest.Apply(
+		fstest.RemoveAll("/d0"),
+		fstest.RemoveAll("/d1"),
+	)
+	diff := []TestChange{
+		Delete("/d0"),
+		Delete("/d1"),
+	}
+
+	if err := testDiffWithBase(l1, l2, diff); err != nil {
+		t.Fatalf("Failed diff with base: %+v", err)
+	}
+}
+
 func TestDirectoryReplace(t *testing.T) {
 	skipDiffTestOnWindows(t)
 	l1 := fstest.Apply(
@@ -143,6 +165,7 @@ func TestParentDirectoryPermission(t *testing.T) {
 		t.Fatalf("Failed diff with base: %+v", err)
 	}
 }
+
 func TestUpdateWithSameTime(t *testing.T) {
 	skipDiffTestOnWindows(t)
 	tt := time.Now().Truncate(time.Second)


### PR DESCRIPTION
Fixes a bug where rmdir was not getting set on a directory if the
previous change was also a directory.

This also needs to be cherry-picked into containerd 1.0.x