### PR TITLE
Add time type conversion for 32 bit linix platforms

### DIFF
--- a/fs/stat_linux.go
+++ b/fs/stat_linux.go
@@ -22,5 +22,5 @@ func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 
 // StatATimeAsTime returns st.Atim as a time.Time
 func StatATimeAsTime(st *syscall.Stat_t) time.Time {
-	return time.Unix(st.Atim.Sec, st.Atim.Nsec)
+	return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) // nolint: unconvert
 }


### PR DESCRIPTION
Ensures the time.Unix function is given int64 arguments. I'm running 32 bit Debian 9.1-- this fixes the following error when building `containerd` after [this PR](https://github.com/containerd/containerd/pull/2113) added the continuity fs package to `containerd`:
```
# github.com/containerd/containerd/vendor/github.com/containerd/continuity/fs
../../containerd/containerd/vendor/github.com/containerd/continuity/fs/stat_linux.go:25:26: cannot use st.Atim.Sec (type int32) as type int64 in argument to time.Unix
../../containerd/containerd/vendor/github.com/containerd/continuity/fs/stat_linux.go:25:39: cannot use st.Atim.Nsec (type int32) as type int64 in argument to time.Unix
```

I recently had a [PR merged](https://github.com/containerd/containerd/pull/2099) for pretty much the same fix in the `containerd` repo