### PR TITLE
Add comment about why an int64 conversion is needed in fs.StatATimeAsTime

### DIFF
--- a/fs/stat_linux.go
+++ b/fs/stat_linux.go
@@ -22,5 +22,6 @@ func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 
 // StatATimeAsTime returns st.Atim as a time.Time
 func StatATimeAsTime(st *syscall.Stat_t) time.Time {
+	// The int64 conversions ensure the line compiles for 32-bit systems as well.
 	return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) // nolint: unconvert
 }


### PR DESCRIPTION
Follow up to #105 