### PR TITLE
Fix copy_file_range usage for files > 2GB

### DIFF
--- a/fs/copy_test.go
+++ b/fs/copy_test.go
@@ -1,11 +1,11 @@
 package fs
 
 import (
+	_ "crypto/sha256"
+	"io"
 	"io/ioutil"
 	"os"
 	"testing"
-
-	_ "crypto/sha256"
 
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/pkg/errors"
@@ -43,6 +43,45 @@ func TestCopyDirectoryWithLocalSymlink(t *testing.T) {
 
 	if err := testCopy(apply); err != nil {
 		t.Fatalf("Copy test failed: %+v", err)
+	}
+}
+
+// TestCopyWithLargeFile tests copying a file whose size > 2^32 bytes.
+func TestCopyWithLargeFile(t *testing.T) {
+	dataR, dataW := io.Pipe()
+	var written int64
+	max := int64(3 * 1024 * 1024 * 1024)
+	defer dataR.Close()
+
+	go func() {
+		var (
+			data = make([]byte, 64*1024)
+			err  error
+			n    int
+		)
+		defer func() {
+			dataW.CloseWithError(err)
+		}()
+
+		for written < max {
+			n, err = dataW.Write(data)
+			if err != nil {
+				return
+			}
+			written += int64(n)
+		}
+	}()
+
+	apply := fstest.Apply(
+		fstest.CreateDir("/banana", 0755),
+		fstest.WriteFileStream("/banana/split", dataR, 0644),
+	)
+
+	if err := testCopy(apply); err != nil {
+		t.Fatal(err)
+	}
+	if written < max {
+		t.Fatalf("wrote fewer bytes than expected: %d", written)
 	}
 }
 


### PR DESCRIPTION
copy_file_range (or any Linux syscall) will only ever copy 2GB at a
time. In this case there is no error returned from the system call.

This fix uses copy_file_range in a loop until either 0 bytes are copied,
or the desired amount has been copied (st.Size()).