### PR TITLE
Update TestCopyWithLargeFile

### DIFF
--- a/fs/copy_test.go
+++ b/fs/copy_test.go
@@ -2,10 +2,10 @@ package fs
 
 import (
 	_ "crypto/sha256"
-	"io"
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/pkg/errors"
@@ -48,40 +48,16 @@ func TestCopyDirectoryWithLocalSymlink(t *testing.T) {
 
 // TestCopyWithLargeFile tests copying a file whose size > 2^32 bytes.
 func TestCopyWithLargeFile(t *testing.T) {
-	dataR, dataW := io.Pipe()
-	var written int64
-	max := int64(3 * 1024 * 1024 * 1024)
-	defer dataR.Close()
-
-	go func() {
-		var (
-			data = make([]byte, 64*1024)
-			err  error
-			n    int
-		)
-		defer func() {
-			dataW.CloseWithError(err)
-		}()
-
-		for written < max {
-			n, err = dataW.Write(data)
-			if err != nil {
-				return
-			}
-			written += int64(n)
-		}
-	}()
-
+	if testing.Short() {
+		t.SkipNow()
+	}
 	apply := fstest.Apply(
 		fstest.CreateDir("/banana", 0755),
-		fstest.WriteFileStream("/banana/split", dataR, 0644),
+		fstest.CreateRandomFile("/banana/split", time.Now().UnixNano(), 3*1024*1024*1024, 0644),
 	)
 
 	if err := testCopy(apply); err != nil {
 		t.Fatal(err)
-	}
-	if written < max {
-		t.Fatalf("wrote fewer bytes than expected: %d", written)
 	}
 }
 

--- a/fs/fstest/file.go
+++ b/fs/fstest/file.go
@@ -3,6 +3,7 @@ package fstest
 import (
 	"bytes"
 	"io"
+	"math/rand"
 	"net"
 	"os"
 	"path/filepath"
@@ -23,12 +24,18 @@ func (a applyFn) Apply(root string) error {
 // CreateFile returns a file applier which creates a file as the
 // provided name with the given content and permission.
 func CreateFile(name string, content []byte, perm os.FileMode) Applier {
-	return WriteFileStream(name, bytes.NewReader(content), perm)
+	return writeFileStream(name, bytes.NewReader(content), perm)
 }
 
-// WriteFileStream returns a file applier which creates a file as the
+// CreateRandomFile returns a file applier which creates a file with random
+// content of the given size using the given seed and permission.
+func CreateRandomFile(name string, seed, size int64, perm os.FileMode) Applier {
+	return writeFileStream(name, io.LimitReader(rand.New(rand.NewSource(seed)), size), perm)
+}
+
+// writeFileStream returns a file applier which creates a file as the
 // provided name with the given content from the provided i/o stream and permission.
-func WriteFileStream(name string, stream io.Reader, perm os.FileMode) Applier {
+func writeFileStream(name string, stream io.Reader, perm os.FileMode) Applier {
 	return applyFn(func(root string) (retErr error) {
 		fullPath := filepath.Join(root, name)
 		f, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)


### PR DESCRIPTION
Add helper to create random files of any size and skip large file copy when short flag is given.