### PR TITLE
driver/{Mknod,Mkfifo,Lchmod}: return PathError

### DIFF
--- a/driver/driver_unix.go
+++ b/driver/driver_unix.go
@@ -13,7 +13,11 @@ import (
 )
 
 func (d *driver) Mknod(path string, mode os.FileMode, major, minor int) error {
-	return devices.Mknod(path, mode, major, minor)
+	err := devices.Mknod(path, mode, major, minor)
+	if err != nil {
+		err = &os.PathError{Op: "mknod", Path: path, Err: err}
+	}
+	return err
 }
 
 func (d *driver) Mkfifo(path string, mode os.FileMode) error {
@@ -22,7 +26,11 @@ func (d *driver) Mkfifo(path string, mode os.FileMode) error {
 	}
 	// mknod with a mode that has ModeNamedPipe set creates a fifo, not a
 	// device.
-	return devices.Mknod(path, mode, 0, 0)
+	err := devices.Mknod(path, mode, 0, 0)
+	if err != nil {
+		err = &os.PathError{Op: "mkfifo", Path: path, Err: err}
+	}
+	return err
 }
 
 // Getxattr returns all of the extended attributes for the file at path p.

--- a/driver/driver_windows.go
+++ b/driver/driver_windows.go
@@ -4,15 +4,14 @@ import (
 	"os"
 
 	"github.com/containerd/continuity/sysx"
-	"github.com/pkg/errors"
 )
 
 func (d *driver) Mknod(path string, mode os.FileMode, major, minor int) error {
-	return errors.Wrap(ErrNotSupported, "cannot create device node on Windows")
+	return &os.PathError{Op: "mknod", Path: path, Err: ErrNotSupported}
 }
 
 func (d *driver) Mkfifo(path string, mode os.FileMode) error {
-	return errors.Wrap(ErrNotSupported, "cannot create fifo on Windows")
+	return &os.PathError{Op: "mkfifo", Path: path, Err: ErrNotSupported}
 }
 
 // Lchmod changes the mode of an file not following symlinks.

--- a/driver/lchmod_linux.go
+++ b/driver/lchmod_linux.go
@@ -15,5 +15,9 @@ func (d *driver) Lchmod(path string, mode os.FileMode) error {
 		return nil
 	}
 
-	return unix.Fchmodat(unix.AT_FDCWD, path, uint32(mode), 0)
+	err := unix.Fchmodat(unix.AT_FDCWD, path, uint32(mode), 0)
+	if err != nil {
+		err = &os.PathError{Op: "lchmod", Path: path, Err: err}
+	}
+	return err
 }

--- a/driver/lchmod_unix.go
+++ b/driver/lchmod_unix.go
@@ -10,5 +10,9 @@ import (
 
 // Lchmod changes the mode of a file not following symlinks.
 func (d *driver) Lchmod(path string, mode os.FileMode) error {
-	return unix.Fchmodat(unix.AT_FDCWD, path, uint32(mode), unix.AT_SYMLINK_NOFOLLOW)
+	err := unix.Fchmodat(unix.AT_FDCWD, path, uint32(mode), unix.AT_SYMLINK_NOFOLLOW)
+	if err != nil {
+		err = &os.PathError{Op: "lchmod", Path: path, Err: err}
+	}
+	return err
 }


### PR DESCRIPTION
In case any of these methods fail, make sure to return an error wrapped
in `os.PathError`, to be in line with the other methods (most of which are
wrappers for `os.Foo()` calls, which return `os.PathError` or `os.LinkError`).