### PR TITLE
feature: expose atomicWriterFile function as AtomicWriteFile

### DIFF
--- a/context.go
+++ b/context.go
@@ -12,11 +12,14 @@ import (
 	"github.com/containerd/continuity/devices"
 	driverpkg "github.com/containerd/continuity/driver"
 	"github.com/containerd/continuity/pathdriver"
+
 	"github.com/opencontainers/go-digest"
 )
 
 var (
-	ErrNotFound     = fmt.Errorf("not found")
+	// ErrNotFound represents the resource not found
+	ErrNotFound = fmt.Errorf("not found")
+	// ErrNotSupported represents the resource not supported
 	ErrNotSupported = fmt.Errorf("not supported")
 )
 
@@ -36,6 +39,7 @@ type Context interface {
 // not under the given root.
 type SymlinkPath func(root, linkname, target string) (string, error)
 
+// ContextOptions represents options to create a new context.
 type ContextOptions struct {
 	Digester   Digester
 	Driver     driverpkg.Driver
@@ -379,7 +383,7 @@ func (c *context) checkoutFile(fp string, rf RegularFile) error {
 	}
 	defer r.Close()
 
-	return atomicWriteFile(fp, r, rf)
+	return atomicWriteFile(fp, r, rf.Size(), rf.Mode())
 }
 
 // Apply the resource to the contexts. An error will be returned if the

--- a/ioutils.go
+++ b/ioutils.go
@@ -1,26 +1,34 @@
 package continuity
 
 import (
+	"bytes"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 )
 
+// AtomicWriteFile atomically writes data to a file by first writing to a
+// temp file and calling rename.
+func AtomicWriteFile(filename string, data []byte, perm os.FileMode) error {
+	buf := bytes.NewBuffer(data)
+	return atomicWriteFile(filename, buf, int64(len(data)), perm)
+}
+
 // atomicWriteFile writes data to a file by first writing to a temp
 // file and calling rename.
-func atomicWriteFile(filename string, r io.Reader, rf RegularFile) error {
+func atomicWriteFile(filename string, r io.Reader, dataSize int64, perm os.FileMode) error {
 	f, err := ioutil.TempFile(filepath.Dir(filename), ".tmp-"+filepath.Base(filename))
 	if err != nil {
 		return err
 	}
-	err = os.Chmod(f.Name(), rf.Mode())
+	err = os.Chmod(f.Name(), perm)
 	if err != nil {
 		f.Close()
 		return err
 	}
 	n, err := io.Copy(f, r)
-	if err == nil && n < rf.Size() {
+	if err == nil && n < dataSize {
 		f.Close()
 		return io.ErrShortWrite
 	}

--- a/ioutils_test.go
+++ b/ioutils_test.go
@@ -1,0 +1,39 @@
+package continuity
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAtomicWriteFile(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "atomic-write-test")
+	if err != nil {
+		t.Fatalf("Error when creating temporary directory: %s", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	expected := []byte("barbaz")
+	if err := AtomicWriteFile(filepath.Join(tmpDir, "foo"), expected, 0666); err != nil {
+		t.Fatalf("Error writing to file: %v", err)
+	}
+
+	actual, err := ioutil.ReadFile(filepath.Join(tmpDir, "foo"))
+	if err != nil {
+		t.Fatalf("Error reading from file: %v", err)
+	}
+
+	if bytes.Compare(actual, expected) != 0 {
+		t.Fatalf("Data mismatch, expected %q, got %q", expected, actual)
+	}
+
+	st, err := os.Stat(filepath.Join(tmpDir, "foo"))
+	if err != nil {
+		t.Fatalf("Error statting file: %v", err)
+	}
+	if expected := os.FileMode(0666); st.Mode() != expected {
+		t.Fatalf("Mode mismatched, expected %o, got %o", expected, st.Mode())
+	}
+}


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

we need `AtomicWriteFile` in `containerd`, so i expose it in here.