### PR TITLE
testutil: sync with containerd

### DIFF
--- a/testutil/loopback_linux.go
+++ b/testutil/loopback_linux.go
@@ -1,5 +1,21 @@
 // +build linux
 
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package testutil
 
 import (
@@ -21,6 +37,8 @@ func NewLoopback(size int64) (string, func() error, error) {
 	}
 
 	if err := file.Truncate(size); err != nil {
+		file.Close()
+		os.Remove(file.Name())
 		return "", nil, errors.Wrap(err, "failed to resize temp file")
 	}
 	file.Close()
@@ -29,6 +47,7 @@ func NewLoopback(size int64) (string, func() error, error) {
 	losetup := exec.Command("losetup", "--find", "--show", file.Name())
 	p, err := losetup.Output()
 	if err != nil {
+		os.Remove(file.Name())
 		return "", nil, errors.Wrap(err, "loopback setup failed")
 	}
 


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

Port over https://github.com/containerd/containerd/blob/master/pkg/testutil/loopback_linux.go


After this PR gets merged we can remove the corresponding code from containerd and vendor continuity

@stevvooe @dmcgowan 