### PR TITLE
Add common project validation scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,19 @@ env:
   - TRAVIS_GOOS=linux
   - TRAVIS_GOOS=darwin
 
+install:
+  - go get -u github.com/vbatts/git-validation
+  - go get -u github.com/kunalkushwaha/ltag
+  - go get -u github.com/LK4D4/vndr
+
+before_script:
+  - pushd ..; git clone https://github.com/containerd/project; popd
+
 script:
   - export GOOS=${TRAVIS_GOOS}
+  - DCO_VERBOSITY=-q ../project/script/validate/dco
+  - ../project/script/validate/fileheader ../project/
+  - ../project/script/validate/vendor
   - make build binaries
   - if [ "$GOOS" = "linux" ]; then make vet test; fi
   - if [ "$GOOS" != "linux" ]; then make test-compile; fi


### PR DESCRIPTION
Test using common validation scripts/templates from containerd/project
and add them to continuity's travis config.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

~~*This will fail until the fileheader PR is merged and I rebase; just a testbed to make sure I get the scripts right*~~