### PR TITLE
Switch from x/net/context to context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: go
 sudo: required
 
 go:
-  - 1.8.x
   - 1.9.x
   - 1.10.x
-  - 1.x
+  - 1.11.x
   - tip
 
 go_import_path: github.com/containerd/continuity

--- a/continuityfs/fuse.go
+++ b/continuityfs/fuse.go
@@ -19,6 +19,7 @@
 package continuityfs
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -31,7 +32,6 @@ import (
 	"github.com/containerd/continuity"
 	"github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // File represents any file type (non directory) in the filesystem


### PR DESCRIPTION
Since go 1.7, "context" is a standard package. Since go 1.9,
x/net/context merelyprovides some types aliased to those in the
standard context package, so there is no functional change.

PS is there any "the most trivial PR of the year" contest? I'd like to nominate this one please.