### PR TITLE
Remove unreachable block in fs path cleanup

### DIFF
--- a/fs/path.go
+++ b/fs/path.go
@@ -248,12 +248,6 @@ func walkLink(root, path string, linksWalked *int) (newpath string, islink bool,
 	if err != nil {
 		return "", false, err
 	}
-	if filepath.IsAbs(newpath) && strings.HasPrefix(newpath, root) {
-		newpath = newpath[:len(root)]
-		if !strings.HasPrefix(newpath, "/") {
-			newpath = "/" + newpath
-		}
-	}
 	*linksWalked++
 	return newpath, true, nil
 }


### PR DESCRIPTION
The block checking for the root as a prefix of an absolute link is unnecessary since the end path always gets joined with the root. In the case where the symlink path is prefixed with the root, this should be considered coincidental and the unit tests already show that the root gets correctly applied to absolute links. 

Additionally inside this block there is a bug causing in incorrect truncation of the path which would
only manifest itself in this rare coincidental case.

ping @tonistiigi 
