### PR TITLE
split testutil/loopback_linux.go to another pkg

### DIFF
--- a/fs/dtype_linux_test.go
+++ b/fs/dtype_linux_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/containerd/continuity/testutil"
+	"github.com/containerd/continuity/testutil/loopback"
 )
 
 func testSupportsDType(t *testing.T, expected bool, mkfs ...string) {
@@ -35,7 +36,7 @@ func testSupportsDType(t *testing.T, expected bool, mkfs ...string) {
 	}
 	defer os.RemoveAll(mnt)
 
-	deviceName, cleanupDevice, err := testutil.NewLoopback(100 << 20) // 100 MB
+	deviceName, cleanupDevice, err := loopback.New(100 << 20) // 100 MB
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testutil/loopback/loopback_linux.go
+++ b/testutil/loopback/loopback_linux.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package testutil
+package loopback
 
 import (
 	"io/ioutil"
@@ -28,8 +28,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// NewLoopback creates a loopback device, and returns its device name (/dev/loopX), and its clean-up function.
-func NewLoopback(size int64) (string, func() error, error) {
+// New creates a loopback device, and returns its device name (/dev/loopX), and its clean-up function.
+func New(size int64) (string, func() error, error) {
 	// create temporary file for the disk image
 	file, err := ioutil.TempFile("", "containerd-test-loopback")
 	if err != nil {


### PR DESCRIPTION
containerd/containerd#2694 is going to import both `containerd/pkg/testutil` and
`continuity/testutil` for deduplicating `NewLoopback()`.

However, as the both pkg defines `test.root` BoolVar in `init()`, the test panics.

This commit avoids the panic issue by splitting `continuity/testutil/loopback_linux.go`
to another pkg (`continuity/testutil/loopback`), so taht containerd does not need to import
both `containerd/pkg/testutil` and `continuity/testutil`.
i.e. containerd will import `containerd/pkg/testutil` and `continuity/testutil/loopback`.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>