### PR TITLE
fs: add WithAllowXAttrErrors CopyOpt

### DIFF
--- a/fs/copy.go
+++ b/fs/copy.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 var bufferPool = &sync.Pool{
@@ -32,14 +33,33 @@ var bufferPool = &sync.Pool{
 	},
 }
 
-// CopyDir copies the directory from src to dst.
-// Most efficient copy of files is attempted.
-func CopyDir(dst, src string) error {
-	inodes := map[uint64]string{}
-	return copyDirectory(dst, src, inodes)
+type copyDirOpts struct {
+	allowXAttrErrors bool
 }
 
-func copyDirectory(dst, src string, inodes map[uint64]string) error {
+type CopyDirOpt func(*copyDirOpts) error
+
+func WithAllowXAttrErrors() CopyDirOpt {
+	return func(o *copyDirOpts) error {
+		o.allowXAttrErrors = true
+		return nil
+	}
+}
+
+// CopyDir copies the directory from src to dst.
+// Most efficient copy of files is attempted.
+func CopyDir(dst, src string, opts ...CopyDirOpt) error {
+	var o copyDirOpts
+	for _, opt := range opts {
+		if err := opt(&o); err != nil {
+			return err
+		}
+	}
+	inodes := map[uint64]string{}
+	return copyDirectory(dst, src, inodes, &o)
+}
+
+func copyDirectory(dst, src string, inodes map[uint64]string, o *copyDirOpts) error {
 	stat, err := os.Stat(src)
 	if err != nil {
 		return errors.Wrapf(err, "failed to stat %s", src)
@@ -75,7 +95,7 @@ func copyDirectory(dst, src string, inodes map[uint64]string) error {
 
 		switch {
 		case fi.IsDir():
-			if err := copyDirectory(target, source, inodes); err != nil {
+			if err := copyDirectory(target, source, inodes, o); err != nil {
 				return err
 			}
 			continue
@@ -112,7 +132,11 @@ func copyDirectory(dst, src string, inodes map[uint64]string) error {
 		}
 
 		if err := copyXAttrs(target, source); err != nil {
-			return errors.Wrap(err, "failed to copy xattrs")
+			if o.allowXAttrErrors {
+				logrus.Warnf("failed to copy xattrs from %s to %s: %v", source, target, err)
+			} else {
+				return errors.Wrap(err, "failed to copy xattrs")
+			}
 		}
 	}
 

--- a/fs/copy.go
+++ b/fs/copy.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 var bufferPool = &sync.Pool{
@@ -131,12 +130,8 @@ func copyDirectory(dst, src string, inodes map[uint64]string, o *copyDirOpts) er
 			return errors.Wrap(err, "failed to copy file info")
 		}
 
-		if err := copyXAttrs(target, source); err != nil {
-			if o.allowXAttrErrors {
-				logrus.Warnf("failed to copy xattrs from %s to %s: %v", source, target, err)
-			} else {
-				return errors.Wrap(err, "failed to copy xattrs")
-			}
+		if err := copyXAttrs(target, source, o.allowXAttrErrors); err != nil {
+			return errors.Wrap(err, "failed to copy xattrs")
 		}
 	}
 

--- a/fs/copy_linux.go
+++ b/fs/copy_linux.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 
 	"github.com/containerd/continuity/sysx"
+	"github.com/sirupsen/logrus"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -101,18 +102,33 @@ func copyFileContent(dst, src *os.File) error {
 	return nil
 }
 
-func copyXAttrs(dst, src string) error {
+func copyXAttrs(dst, src string, allowErrors bool) error {
 	xattrKeys, err := sysx.LListxattr(src)
 	if err != nil {
-		return errors.Wrapf(err, "failed to list xattrs on %s", src)
+		e := errors.Wrapf(err, "failed to list xattrs on %s", src)
+		if allowErrors {
+			logrus.Warnf("%v", e)
+			return nil
+		}
+		return e
 	}
 	for _, xattr := range xattrKeys {
 		data, err := sysx.LGetxattr(src, xattr)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src)
+			e := errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src)
+			if allowErrors {
+				logrus.Warnf("%v", e)
+				return nil
+			}
+			return e
 		}
 		if err := sysx.LSetxattr(dst, xattr, data, 0); err != nil {
-			return errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst)
+			e := errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst)
+			if allowErrors {
+				logrus.Warnf("%v", e)
+				return nil
+			}
+			return e
 		}
 	}
 

--- a/fs/copy_unix.go
+++ b/fs/copy_unix.go
@@ -24,6 +24,7 @@ import (
 	"syscall"
 
 	"github.com/containerd/continuity/sysx"
+	"github.com/sirupsen/logrus"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -69,18 +70,33 @@ func copyFileContent(dst, src *os.File) error {
 	return err
 }
 
-func copyXAttrs(dst, src string) error {
+func copyXAttrs(dst, src string, allowErrors bool) error {
 	xattrKeys, err := sysx.LListxattr(src)
 	if err != nil {
-		return errors.Wrapf(err, "failed to list xattrs on %s", src)
+		e := errors.Wrapf(err, "failed to list xattrs on %s", src)
+		if allowErrors {
+			logrus.Warnf("%v", e)
+			return nil
+		}
+		return e
 	}
 	for _, xattr := range xattrKeys {
 		data, err := sysx.LGetxattr(src, xattr)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src)
+			e := errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src)
+			if allowErrors {
+				logrus.Warnf("%v", e)
+				return nil
+			}
+			return e
 		}
 		if err := sysx.LSetxattr(dst, xattr, data, 0); err != nil {
-			return errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst)
+			e := errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst)
+			if allowErrors {
+				logrus.Warnf("%v", e)
+				return nil
+			}
+			return e
 		}
 	}
 

--- a/fs/copy_windows.go
+++ b/fs/copy_windows.go
@@ -40,7 +40,7 @@ func copyFileContent(dst, src *os.File) error {
 	return err
 }
 
-func copyXAttrs(dst, src string, allowErrors bool) error {
+func copyXAttrs(dst, src string, xeh XAttrErrorHandler) error {
 	return nil
 }
 

--- a/fs/copy_windows.go
+++ b/fs/copy_windows.go
@@ -40,7 +40,7 @@ func copyFileContent(dst, src *os.File) error {
 	return err
 }
 
-func copyXAttrs(dst, src string) error {
+func copyXAttrs(dst, src string, allowErrors bool) error {
 	return nil
 }
 


### PR DESCRIPTION
This option allows ignoring errors during copying xattr like `security.selinux`,
which is not always supported.

Reported in several issues including
* https://github.com/openfaas/openfaas-cloud/issues/312
* https://github.com/moby/buildkit/issues/704
* https://github.com/genuinetools/img/issues/45
* https://bugzilla.redhat.com/show_bug.cgi?id=1596918

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>