### PR TITLE
Fix directory comparison in changes

### DIFF
--- a/fs/diff_test.go
+++ b/fs/diff_test.go
@@ -135,6 +135,26 @@ func TestRemoveDirectoryTree(t *testing.T) {
 	}
 }
 
+func TestRemoveDirectoryTreeWithDash(t *testing.T) {
+	l1 := fstest.Apply(
+		fstest.CreateDir("/dir1/dir2/dir3", 0755),
+		fstest.CreateFile("/dir1/f1", []byte("f1"), 0644),
+		fstest.CreateFile("/dir1/dir2/f2", []byte("f2"), 0644),
+		fstest.CreateDir("/dir1-before", 0755),
+		fstest.CreateFile("/dir1-before/f2", []byte("f2"), 0644),
+	)
+	l2 := fstest.Apply(
+		fstest.RemoveAll("/dir1"),
+	)
+	diff := []TestChange{
+		Delete("/dir1"),
+	}
+
+	if err := testDiffWithBase(l1, l2, diff); err != nil {
+		t.Fatalf("Failed diff with base: %+v", err)
+	}
+}
+
 func TestFileReplace(t *testing.T) {
 	l1 := fstest.Apply(
 		fstest.CreateFile("/dir1", []byte("a file, not a directory"), 0644),

--- a/fs/path.go
+++ b/fs/path.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -47,9 +46,8 @@ func pathChange(lower, upper *currentPath) (ChangeKind, string) {
 	if upper == nil {
 		return ChangeKindDelete, lower.path
 	}
-	// TODO: compare by directory
 
-	switch i := strings.Compare(lower.path, upper.path); {
+	switch i := directoryCompare(lower.path, upper.path); {
 	case i < 0:
 		// File in lower that is not in upper
 		return ChangeKindDelete, lower.path
@@ -59,6 +57,35 @@ func pathChange(lower, upper *currentPath) (ChangeKind, string) {
 	default:
 		return ChangeKindModify, upper.path
 	}
+}
+
+func directoryCompare(a, b string) int {
+	l := len(a)
+	if len(b) < l {
+		l = len(b)
+	}
+	for i := 0; i < l; i++ {
+		c1, c2 := a[i], b[i]
+		if c1 == filepath.Separator {
+			c1 = byte(0)
+		}
+		if c2 == filepath.Separator {
+			c2 = byte(0)
+		}
+		if c1 < c2 {
+			return -1
+		}
+		if c1 > c2 {
+			return +1
+		}
+	}
+	if len(a) < len(b) {
+		return -1
+	}
+	if len(a) > len(b) {
+		return +1
+	}
+	return 0
 }
 
 func sameFile(f1, f2 *currentPath) (bool, error) {

--- a/fs/path_test.go
+++ b/fs/path_test.go
@@ -183,6 +183,51 @@ func TestRootPath(t *testing.T) {
 	t.Run("SymlinkEmpty", testRootPathSymlinkEmpty)
 }
 
+func TestDirectoryCompare(t *testing.T) {
+	for i, tc := range []struct {
+		p1 string
+		p2 string
+		r  int
+	}{
+		{"", "", 0},
+		{"", "/", -1},
+		{"/", "", 1},
+		{"/", "/", 0},
+		{"", "", 0},
+		{"/dir1", "/dir1/", -1},
+		{"/dir1", "/dir1", 0},
+		{"/dir1/", "/dir1", 1},
+		{"/dir1", "/dir2", -1},
+		{"/dir2", "/dir1", 1},
+		{"/dir1/1", "/dir1-1", -1},
+		{"/dir1-1", "/dir1/1", 1},
+		{"/dir1/dir2", "/dir1/dir2", 0},
+		{"/dir1/dir2", "/dir1/dir2/", -1},
+		{"/dir1/dir2", "/dir1/dir2/f1", -1},
+		{"/dir1/dir2/", "/dir1/dir2", 1},
+		{"/dir1/dir2/f1", "/dir1/dir2", 1},
+		{"/dir1/dir2-f1", "/dir1/dir2", 1},
+		{"/dir1/dir2-f1", "/dir1/dir2/", 1},
+		{"/dir1/dir2/", "/dir1/dir2/", 0},
+		{"/dir1/dir2你", "/dir1/dir2a", 1},
+		{"/dir1/dir2你", "/dir1/dir2", 1},
+		{"/dir1/dir2你", "/dir1/dir2/", 1},
+		{"/dir1/dir2你/", "/dir1/dir2/", 1},
+		{"/dir1/dir2你/", "/dir1/dir2你/", 0},
+		{"/dir1/dir2你/", "/dir1/dir2你好/", -1},
+		{"/dir1/dir2你/", "/dir1/dir2你-好/", -1},
+		{"/dir1/dir2你/", "/dir1/dir2好/", -1},
+		{"/dir1/dir2/f1", "/dir1/dir2/f1", 0},
+		{"/d1/d2/d3/d4/d5/d6/d7/d8/d9/d10", "/d1/d2/d3/d4/d5/d6/d7/d8/d9/d10", 0},
+		{"/d1/d2/d3/d4/d5/d6/d7/d8/d9/d10", "/d1/d2/d3/d4/d5/d6/d7/d8/d9/d11", -1},
+	} {
+		r := directoryCompare(tc.p1, tc.p2)
+		if r != tc.r {
+			t.Errorf("[%d] Test case failed, %q <> %q = %d, expected %d", i, tc.p1, tc.p2, r, tc.r)
+		}
+	}
+}
+
 func testRootPathSymlinkRootScope(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "TestFollowSymlinkRootScope")
 	if err != nil {
@@ -202,6 +247,7 @@ func testRootPathSymlinkRootScope(t *testing.T) {
 		t.Fatalf("expected %q got %q", expected, rewrite)
 	}
 }
+
 func testRootPathSymlinkEmpty(t *testing.T) {
 	wd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
Currently string comparison is used to detect changes. The comparisons are already done ordered, however since `-` will compare before `/`, a directory deletion which also has a directory ending with `-` can cause the wrong change output. The comparisons must be done considering directory separators as the lowest sorting value.

Related to https://github.com/moby/buildkit/issues/960
