### PR TITLE
Add src string to copyDirectory error message.

### DIFF
--- a/fs/copy.go
+++ b/fs/copy.go
@@ -80,7 +80,7 @@ func copyDirectory(dst, src string, inodes map[uint64]string, o *copyDirOpts) er
 		return errors.Wrapf(err, "failed to stat %s", src)
 	}
 	if !stat.IsDir() {
-		return errors.Errorf("source is not directory")
+		return errors.Errorf("source %s is not directory", src)
 	}
 
 	if st, err := os.Stat(dst); err != nil {


### PR DESCRIPTION
Proposal to display the wrongful `src` path in the error message. For example, this error can popup in the Microk8s Kubernetes deployment dashboard. A notion of which src path is referred to would be helpful.