### PR TITLE
fs: don't convert syscall.Timespec to unix.Timespec directly

### DIFF
--- a/fs/copy_linux.go
+++ b/fs/copy_linux.go
@@ -51,7 +51,10 @@ func copyFileInfo(fi os.FileInfo, name string) error {
 		}
 	}
 
-	timespec := []unix.Timespec{unix.Timespec(StatAtime(st)), unix.Timespec(StatMtime(st))}
+	timespec := []unix.Timespec{
+		unix.NsecToTimespec(syscall.TimespecToNsec(StatAtime(st))),
+		unix.NsecToTimespec(syscall.TimespecToNsec(StatMtime(st))),
+	}
 	if err := unix.UtimesNanoAt(unix.AT_FDCWD, name, timespec, unix.AT_SYMLINK_NOFOLLOW); err != nil {
 		return errors.Wrapf(err, "failed to utime %s", name)
 	}


### PR DESCRIPTION
This doesn't work with gccgo.

```
vendor/github.com/containerd/continuity/fs/copy_linux.go:54:43: error: invalid type conversion (cannot use type syscall.Timespec as type unix.Timespec)
   54 |  timespec := []unix.Timespec{unix.Timespec(StatAtime(st)), unix.Timespec(StatMtime(st))}
      |                                           ^
vendor/github.com/containerd/continuity/fs/copy_linux.go:54:73: error: invalid type conversion (cannot use type syscall.Timespec as type unix.Timespec)
   54 |  timespec := []unix.Timespec{unix.Timespec(StatAtime(st)), unix.Timespec(StatMtime(st))}
      |                                                                         ^
```

Instead, using an int64 nanosec variable as the bridge.