### PR TITLE
Fix sameFile() to recognize empty files as the same

### DIFF
--- a/fs/diff_test.go
+++ b/fs/diff_test.go
@@ -72,6 +72,22 @@ func TestSimpleDiff(t *testing.T) {
 	}
 }
 
+func TestEmptyFileDiff(t *testing.T) {
+	skipDiffTestOnWindows(t)
+	tt := time.Now().Truncate(time.Second)
+	l1 := fstest.Apply(
+		fstest.CreateDir("/etc", 0755),
+		fstest.CreateFile("/etc/empty", []byte(""), 0644),
+		fstest.Chtimes("/etc/empty", tt, tt),
+	)
+	l2 := fstest.Apply()
+	diff := []TestChange{}
+
+	if err := testDiffWithBase(l1, l2, diff); err != nil {
+		t.Fatalf("Failed diff with base: %+v", err)
+	}
+}
+
 func TestNestedDeletion(t *testing.T) {
 	skipDiffTestOnWindows(t)
 	l1 := fstest.Apply(

--- a/fs/path.go
+++ b/fs/path.go
@@ -122,6 +122,8 @@ func sameFile(f1, f2 *currentPath) (bool, error) {
 				eq, err = compareSymlinkTarget(f1.fullPath, f2.fullPath)
 			} else if f1.f.Size() > 0 {
 				eq, err = compareFileContent(f1.fullPath, f2.fullPath)
+			} else {
+				eq, err = true, nil
 			}
 			if err != nil || !eq {
 				return eq, err

--- a/fs/path.go
+++ b/fs/path.go
@@ -123,7 +123,7 @@ func sameFile(f1, f2 *currentPath) (bool, error) {
 			} else if f1.f.Size() > 0 {
 				eq, err = compareFileContent(f1.fullPath, f2.fullPath)
 			} else {
-				eq, err = true, nil
+				eq, err = true, nil // if file sizes are zero length, the files are the same by definition
 			}
 			if err != nil || !eq {
 				return eq, err


### PR DESCRIPTION
This PR fixes issue #152 and adds a test for that case.