### PR TITLE
Migrate to GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,131 @@
+name: Continuity
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  checks:
+    name: CI Checks
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Setup Go binary path
+      shell: bash
+      run: |
+        echo "::set-env name=GOPATH::${{ github.workspace }}"
+        echo "::add-path::${{ github.workspace }}/bin"
+
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+        path: src/github.com/containerd/continuity
+        fetch-depth: 25
+
+    - name: Checkout project
+      uses: actions/checkout@v2
+      with:
+        repository: containerd/project
+        path: src/github.com/containerd/project
+
+    - name: Install dependencies
+      env:
+        GO111MODULE: off
+      run: |
+        go get -u github.com/vbatts/git-validation
+        go get -u github.com/kunalkushwaha/ltag
+
+    - name: Check DCO/whitespace/commit message
+      env:
+        GITHUB_COMMIT_URL: ${{ github.event.pull_request.commits_url }}
+        DCO_VERBOSITY: "-q"
+        DCO_RANGE: ""
+      working-directory: src/github.com/containerd/continuity
+      run: |
+        if [ -z "${GITHUB_COMMIT_URL}" ]; then
+          DCO_RANGE=$(jq -r '.before +".."+ .after' ${GITHUB_EVENT_PATH})
+        else
+          DCO_RANGE=$(curl ${GITHUB_COMMIT_URL} | jq -r '.[0].parents[0].sha +".."+ .[-1].sha')
+        fi
+        ../project/script/validate/dco
+
+    - name: Check file headers
+      run: ../project/script/validate/fileheader ../project/
+      working-directory: src/github.com/containerd/continuity
+
+    - name: Check vendor
+      run: ../project/script/validate/vendor
+      working-directory: src/github.com/containerd/continuity
+
+  tests:
+    name: CI Tests
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    needs: [checks]
+
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+
+    - name: Setup Go binary path
+      shell: bash
+      run: |
+        echo "::set-env name=GOPATH::${{ github.workspace }}"
+        echo "::add-path::${{ github.workspace }}/bin"
+
+    - name: Git line endings
+      shell: bash
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+        path: src/github.com/containerd/continuity
+        fetch-depth: 25
+
+    - name: Dependencies
+      env:
+        GO111MODULE: on
+      shell: bash
+      run: go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.23.8
+
+    - name: Lint
+      shell: bash
+      run: make lint
+      working-directory: src/github.com/containerd/continuity
+
+    - name: Build
+      shell: bash
+      run: make build binaries
+      working-directory: src/github.com/containerd/continuity
+
+    - name: Linux Tests
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+        make test
+        sudo GOPATH=$GOPATH make root-test
+      working-directory: src/github.com/containerd/continuity
+
+    - name: Non-Linux Tests
+      if: ${{ !startsWith(matrix.os, 'ubuntu') }}
+      shell: bash
+      run: make test-compile
+      working-directory: src/github.com/containerd/continuity

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+linters:
+  enable:
+    - structcheck
+    - varcheck
+    - staticcheck
+    - unconvert
+    - gofmt
+    - goimports
+    - golint
+    - ineffassign
+    - vet
+    - unused
+    - misspell
+  disable:
+    - errcheck
+
+run:
+  timeout: 3m

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
 script:
   - export GOOS=${TRAVIS_GOOS}
   - make build binaries
-  - if [ "$GOOS" = "linux" ]; then make vet test; fi
+  - if [ "$GOOS" = "linux" ]; then make test; fi
   - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make root-test; fi
   - if [ "$GOOS" != "linux" ]; then make test-compile; fi
 

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ TEST_REQUIRES_ROOT_PACKAGES=$(filter \
     done | sort -u) \
     )
 
-.PHONY: clean all fmt vet lint build test binaries
+.PHONY: clean all lint build test binaries
 .DEFAULT: default
-# skip lint at the moment
-all: AUTHORS clean fmt vet fmt build test binaries
+
+all: AUTHORS clean lint build test binaries
 
 AUTHORS: .mailmap .git/HEAD
 	 git log --format='%aN <%aE>' | sort -fu > $@

--- a/Makefile
+++ b/Makefile
@@ -52,20 +52,9 @@ ${PREFIX}/bin/continuity: version/version.go $(shell find . -type f -name '*.go'
 generate:
 	go generate -mod=vendor $(PACKAGES)
 
-# Depends on binaries because vet will silently fail if it can't load compiled
-# imports
-vet: binaries
-	@echo "+ $@"
-	@go vet -mod=vendor $(PACKAGES)
-
-fmt:
-	@echo "+ $@"
-	@test -z "$$(gofmt -s -l . | grep -v Godeps/_workspace/src/ | grep -v vendor/ | tee /dev/stderr)" || \
-		echo "+ please format Go code with 'gofmt -s'"
-
 lint:
 	@echo "+ $@"
-	@test -z "$$(golint $(PACKAGES) | grep -v Godeps/_workspace/src/ | grep -v vendor/ |tee /dev/stderr)"
+	@golangci-lint run
 
 build:
 	@echo "+ $@"

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -44,8 +44,10 @@ var LSCmd = &cobra.Command{
 		for _, entry := range bm.Resource {
 			for _, path := range entry.Path {
 				if os.FileMode(entry.Mode)&os.ModeSymlink != 0 {
+					//nolint:unconvert
 					fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v -> %v\n", os.FileMode(entry.Mode), entry.User, entry.Group, humanize.Bytes(uint64(entry.Size)), path, entry.Target)
 				} else {
+					//nolint:unconvert
 					fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", os.FileMode(entry.Mode), entry.User, entry.Group, humanize.Bytes(uint64(entry.Size)), path)
 				}
 

--- a/context.go
+++ b/context.go
@@ -596,7 +596,7 @@ func (c *context) Walk(fn filepath.WalkFunc) error {
 			return err
 		}
 	}
-	return c.pathDriver.Walk(root, func(p string, fi os.FileInfo, err error) error {
+	return c.pathDriver.Walk(root, func(p string, fi os.FileInfo, _ error) error {
 		contained, err := c.containWithRoot(p, root)
 		return fn(contained, fi, err)
 	})
@@ -611,12 +611,6 @@ func (c *context) fullpath(p string) (string, error) {
 	}
 
 	return p, nil
-}
-
-// contain cleans and santizes the filesystem path p to be an absolute path,
-// effectively relative to the context root.
-func (c *context) contain(p string) (string, error) {
-	return c.containWithRoot(p, c.root)
 }
 
 // containWithRoot cleans and santizes the filesystem path p to be an absolute path,

--- a/continuityfs/fuse.go
+++ b/continuityfs/fuse.go
@@ -131,7 +131,7 @@ type fileHandler struct {
 func (h *fileHandler) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
 	if h.offset != req.Offset {
 		if seeker, ok := h.reader.(io.Seeker); ok {
-			if _, err := seeker.Seek(req.Offset, os.SEEK_SET); err != nil {
+			if _, err := seeker.Seek(req.Offset, io.SeekStart); err != nil {
 				logrus.Debugf("Error seeking: %v", err)
 				return err
 			}

--- a/devices/devices_unix.go
+++ b/devices/devices_unix.go
@@ -32,6 +32,7 @@ func DeviceInfo(fi os.FileInfo) (uint64, uint64, error) {
 		return 0, 0, fmt.Errorf("cannot extract device from os.FileInfo")
 	}
 
+	//nolint:unconvert
 	dev := uint64(sys.Rdev)
 	return uint64(unix.Major(dev)), uint64(unix.Minor(dev)), nil
 }

--- a/digests.go
+++ b/digests.go
@@ -88,13 +88,9 @@ func digestsMatch(as, bs []digest.Digest) bool {
 	}
 
 	disjoint := len(as) + len(bs)
-	if len(uniqified) == disjoint {
-		// if these two sets have the same cardinality, we know both sides
-		// didn't share any digests.
-		return false
-	}
-
-	return true
+	// if these two sets have the same cardinality, we know both sides
+	// didn't share any digests.
+	return len(uniqified) != disjoint
 }
 
 type digestSlice []digest.Digest

--- a/driver/driver_windows.go
+++ b/driver/driver_windows.go
@@ -1,3 +1,5 @@
+// +build go1.13
+
 /*
    Copyright The containerd Authors.
 
@@ -13,8 +15,6 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-
-// +build go1.13
 
 // Go 1.13 is the minimally supported version for Windows.
 // Earlier golang releases have bug in os.Readlink

--- a/fs/fstest/continuity_util.go
+++ b/fs/fstest/continuity_util.go
@@ -47,7 +47,7 @@ func (l resourceListDifference) HasDiff() bool {
 	}
 
 	for _, add := range l.Additions {
-		if ok, _ := metadataFiles[add.Path()]; !ok {
+		if ok := metadataFiles[add.Path()]; !ok {
 			return true
 		}
 	}
@@ -66,7 +66,7 @@ func (l resourceListDifference) String() string {
 	for _, upt := range l.Updates {
 		fmt.Fprintf(buf, "~ %s\n", upt.String())
 	}
-	return string(buf.Bytes())
+	return buf.String()
 }
 
 // diffManifest compares two resource lists and returns the list

--- a/fs/fstest/testsuite.go
+++ b/fs/fstest/testsuite.go
@@ -210,7 +210,7 @@ var (
 	}
 
 	// Hardlink name before with modification
-	// Tests link is created for unmodified files when new hardlinked file is seen first
+	// Tests link is created for unmodified files when a new hard linked file is seen first
 	hardlinkBeforeUnmodified = []Applier{
 		baseApplier,
 		Apply(

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/continuity
 
-go 1.11
+go 1.13
 
 require (
 	bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898

--- a/groups_unix.go
+++ b/groups_unix.go
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 
+//nolint:unused,deadcode
 package continuity
 
 import (

--- a/hardlinks.go
+++ b/hardlinks.go
@@ -53,7 +53,7 @@ func (hlm *hardlinkManager) Add(fi os.FileInfo, resource Resource) error {
 }
 
 // Merge processes the current state of the hardlink manager and merges any
-// shared nodes into hardlinked resources.
+// shared nodes into hard linked resources.
 func (hlm *hardlinkManager) Merge() ([]Resource, error) {
 	var resources []Resource
 	for key, linked := range hlm.hardlinks {

--- a/hardlinks_unix.go
+++ b/hardlinks_unix.go
@@ -48,5 +48,6 @@ func newHardlinkKey(fi os.FileInfo) (hardlinkKey, error) {
 		return hardlinkKey{}, errNotAHardLink
 	}
 
+	//nolint:unconvert
 	return hardlinkKey{dev: uint64(sys.Dev), inode: uint64(sys.Ino)}, nil
 }

--- a/ioutils_test.go
+++ b/ioutils_test.go
@@ -41,7 +41,7 @@ func TestAtomicWriteFile(t *testing.T) {
 		t.Fatalf("Error reading from file: %v", err)
 	}
 
-	if bytes.Compare(actual, expected) != 0 {
+	if !bytes.Equal(actual, expected) {
 		t.Fatalf("Data mismatch, expected %q, got %q", expected, actual)
 	}
 

--- a/manifest.go
+++ b/manifest.go
@@ -114,11 +114,13 @@ func BuildManifest(ctx Context) (*Manifest, error) {
 	}
 
 	// merge and post-process the hardlinks.
+	// nolint:misspell
 	hardlinked, err := hardlinks.Merge()
 	if err != nil {
 		return nil, err
 	}
 
+	// nolint:misspell
 	for _, resource := range hardlinked {
 		resourcesByPath[resource.Path()] = resource
 	}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -120,7 +120,7 @@ func TestWalkFS(t *testing.T) {
 		// },
 
 		// TODO(stevvooe): Must add tests for xattrs, with symlinks,
-		// directorys and regular files.
+		// directories and regular files.
 
 		{
 			kind: rnamedpipe,

--- a/resource_test.go
+++ b/resource_test.go
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 
+//nolint:unused,deadcode
 package continuity
 
 type resourceUpdate struct {

--- a/sysx/xattr_unsupported.go
+++ b/sysx/xattr_unsupported.go
@@ -23,7 +23,7 @@ import (
 	"runtime"
 )
 
-var unsupported = errors.New("extended attributes unsupported on " + runtime.GOOS)
+var errUnsupported = errors.New("extended attributes unsupported on " + runtime.GOOS)
 
 // Listxattr calls syscall listxattr and reads all content
 // and returns a string array
@@ -33,17 +33,17 @@ func Listxattr(path string) ([]string, error) {
 
 // Removexattr calls syscall removexattr
 func Removexattr(path string, attr string) (err error) {
-	return unsupported
+	return errUnsupported
 }
 
 // Setxattr calls syscall setxattr
 func Setxattr(path string, attr string, data []byte, flags int) (err error) {
-	return unsupported
+	return errUnsupported
 }
 
 // Getxattr calls syscall getxattr
 func Getxattr(path, attr string) ([]byte, error) {
-	return []byte{}, unsupported
+	return []byte{}, errUnsupported
 }
 
 // LListxattr lists xattrs, not following symlinks
@@ -53,12 +53,12 @@ func LListxattr(path string) ([]string, error) {
 
 // LRemovexattr removes an xattr, not following symlinks
 func LRemovexattr(path string, attr string) (err error) {
-	return unsupported
+	return errUnsupported
 }
 
 // LSetxattr sets an xattr, not following symlinks
 func LSetxattr(path string, attr string, data []byte, flags int) (err error) {
-	return unsupported
+	return errUnsupported
 }
 
 // LGetxattr gets an xattr, not following symlinks

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 
+//nolint:unused,deadcode
 package continuity
 
 import (


### PR DESCRIPTION
A series of commits to make the initial migration step from Travis CI -> GitHub Actions

- Fix all errors marked by running `golangci-lint` locally with the same settings as other containerd projects
- PRs were not being checked for `gofmt` and `vet` was only run on Linux; move to use all-encompassing `golangci-lint` to replace fmt/vet/lint targets in `Makefile`
- set up the CI workflow for GitHub actions