### PR TITLE
Fix usage calculation to account for sparse files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,64 +8,23 @@ on:
 
 jobs:
 
-  checks:
-    name: CI Checks
+  #
+  # Project checks
+  #
+  project:
+    name: Project Checks
     runs-on: ubuntu-18.04
     timeout-minutes: 5
+
     steps:
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/continuity
+          fetch-depth: 100
 
-    - name: Set up Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.15
-      id: go
-
-    - name: Setup Go binary path
-      shell: bash
-      run: |
-        echo "::set-env name=GOPATH::${{ github.workspace }}"
-        echo "::add-path::${{ github.workspace }}/bin"
-
-    - name: Check out code
-      uses: actions/checkout@v2
-      with:
-        path: src/github.com/containerd/continuity
-        fetch-depth: 25
-
-    - name: Checkout project
-      uses: actions/checkout@v2
-      with:
-        repository: containerd/project
-        path: src/github.com/containerd/project
-
-    - name: Install dependencies
-      env:
-        GO111MODULE: off
-      run: |
-        go get -u github.com/vbatts/git-validation
-        go get -u github.com/kunalkushwaha/ltag
-
-    - name: Check DCO/whitespace/commit message
-      env:
-        GITHUB_COMMIT_URL: ${{ github.event.pull_request.commits_url }}
-        DCO_VERBOSITY: "-q"
-        DCO_RANGE: ""
-      working-directory: src/github.com/containerd/continuity
-      run: |
-        if [ -z "${GITHUB_COMMIT_URL}" ]; then
-          DCO_RANGE=$(jq -r '.before +".."+ .after' ${GITHUB_EVENT_PATH})
-        else
-          DCO_RANGE=$(curl ${GITHUB_COMMIT_URL} | jq -r '.[0].parents[0].sha +".."+ .[-1].sha')
-        fi
-        ../project/script/validate/dco
-
-    - name: Check file headers
-      run: ../project/script/validate/fileheader ../project/
-      working-directory: src/github.com/containerd/continuity
-
-    - name: Check vendor
-      run: ../project/script/validate/vendor
-      working-directory: src/github.com/containerd/continuity
+      - uses: containerd/project-checks@v1
+        with:
+          working-directory: src/github.com/containerd/continuity
 
   tests:
     name: CI Tests
@@ -86,8 +45,8 @@ jobs:
     - name: Setup Go binary path
       shell: bash
       run: |
-        echo "::set-env name=GOPATH::${{ github.workspace }}"
-        echo "::add-path::${{ github.workspace }}/bin"
+        echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+        echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
     - name: Git line endings
       shell: bash

--- a/fs/du_unix.go
+++ b/fs/du_unix.go
@@ -59,10 +59,11 @@ func diskUsage(ctx context.Context, roots ...string) (Usage, error) {
 			default:
 			}
 
-			inoKey := newInode(fi.Sys().(*syscall.Stat_t))
+			stat := fi.Sys().(*syscall.Stat_t)
+			inoKey := newInode(stat)
 			if _, ok := inodes[inoKey]; !ok {
 				inodes[inoKey] = struct{}{}
-				size += fi.Size()
+				size += stat.Blocks * stat.Blksize
 			}
 
 			return nil
@@ -89,10 +90,11 @@ func diffUsage(ctx context.Context, a, b string) (Usage, error) {
 		}
 
 		if kind == ChangeKindAdd || kind == ChangeKindModify {
-			inoKey := newInode(fi.Sys().(*syscall.Stat_t))
+			stat := fi.Sys().(*syscall.Stat_t)
+			inoKey := newInode(stat)
 			if _, ok := inodes[inoKey]; !ok {
 				inodes[inoKey] = struct{}{}
-				size += fi.Size()
+				size += stat.Blocks * stat.Blksize
 			}
 
 			return nil


### PR DESCRIPTION
The current usage calculation does not correctly account for usage within spares files. To correctly account for the usage, the number of blocks must be used rather than the reported file size.