### PR TITLE
Fix building on arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     name: CI Tests
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
-    needs: [checks]
+    needs: [project]
 
     strategy:
       matrix:

--- a/fs/du_unix.go
+++ b/fs/du_unix.go
@@ -63,7 +63,8 @@ func diskUsage(ctx context.Context, roots ...string) (Usage, error) {
 			inoKey := newInode(stat)
 			if _, ok := inodes[inoKey]; !ok {
 				inodes[inoKey] = struct{}{}
-				size += stat.Blocks * stat.Blksize
+				// on arm64 stat.Blksize is int32
+				size += stat.Blocks * int64(stat.Blksize) // nolint: unconvert
 			}
 
 			return nil
@@ -94,7 +95,8 @@ func diffUsage(ctx context.Context, a, b string) (Usage, error) {
 			inoKey := newInode(stat)
 			if _, ok := inodes[inoKey]; !ok {
 				inodes[inoKey] = struct{}{}
-				size += stat.Blocks * stat.Blksize
+				// on arm64 stat.Blksize is int32
+				size += stat.Blocks * int64(stat.Blksize) // nolint: unconvert
 			}
 
 			return nil


### PR DESCRIPTION
github.com/containerd/continuity/fs
fs/du_unix.go:66:31: invalid operation: stat.Blocks * stat.Blksize (mismatched types int64 and int32)
fs/du_unix.go:97:31: invalid operation: stat.Blocks * stat.Blksize (mismatched types int64 and int32)

Caused by #163 @dmcgowan