### PR TITLE
Support FreeBSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,13 @@ jobs:
       run: make build binaries
       working-directory: src/github.com/containerd/continuity
 
+    - name: Cross-compile
+      if: startsWith(matrix.os, 'ubuntu')
+      shell: bash
+      run: |
+          GOOS=freebsd make build binaries
+      working-directory: src/github.com/containerd/continuity
+
     - name: Linux Tests
       if: startsWith(matrix.os, 'ubuntu')
       run: |

--- a/AUTHORS
+++ b/AUTHORS
@@ -19,11 +19,15 @@ Justin Cummins <sul3n3t@gmail.com>
 Kasper Fabæch Brandt <poizan@poizan.dk>
 Kir Kolyshkin <kolyshkin@gmail.com>
 Michael Crosby <crosbymichael@gmail.com>
+Michael Crosby <michael@thepasture.io>
 Michael Wan <zirenwan@gmail.com>
+Mike Brown <brownwm@us.ibm.com>
 Niels de Vos <ndevos@redhat.com>
 Phil Estes <estesp@gmail.com>
 Phil Estes <estesp@linux.vnet.ibm.com>
+Samuel Karp <me@samuelkarp.com>
 Sam Whited <sam@samwhited.com>
+Sebastiaan van Stijn <github@gone.nl>
 Shengjing Zhu <zhsj@debian.org>
 Stephen J Day <stephen.day@docker.com>
 Tibor Vass <tibor@docker.com>

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ $ stat -c %a Makefile
 $ ./bin/continuity verify . /tmp/a.pb
 ```
 
+## Platforms
+
+continuity primarily targets Linux.  continuity may compile for and work on
+other operating systems, but those platforms are not tested.
 
 ## Contribution Guide
 ### Building Proto Package

--- a/devices/devices_unix.go
+++ b/devices/devices_unix.go
@@ -56,7 +56,7 @@ func Mknod(p string, mode os.FileMode, maj, min int) error {
 		m |= unix.S_IFIFO
 	}
 
-	return unix.Mknod(p, m, int(dev))
+	return mknod(p, m, dev)
 }
 
 // syscallMode returns the syscall-specific mode bits from Go's portable mode bits.

--- a/devices/mknod_freebsd.go
+++ b/devices/mknod_freebsd.go
@@ -1,0 +1,25 @@
+// +build freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package devices
+
+import "golang.org/x/sys/unix"
+
+func mknod(path string, mode uint32, dev uint64) (err error) {
+	return unix.Mknod(path, mode, dev)
+}

--- a/devices/mknod_unix.go
+++ b/devices/mknod_unix.go
@@ -1,0 +1,25 @@
+// +build linux darwin solaris
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package devices
+
+import "golang.org/x/sys/unix"
+
+func mknod(path string, mode uint32, dev uint64) (err error) {
+	return unix.Mknod(path, mode, int(dev))
+}

--- a/fs/copy_darwinopenbsdsolaris.go
+++ b/fs/copy_darwinopenbsdsolaris.go
@@ -1,0 +1,35 @@
+// +build darwin openbsd solaris
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+func copyDevice(dst string, fi os.FileInfo) error {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("unsupported stat type")
+	}
+	return unix.Mknod(dst, uint32(fi.Mode()), int(st.Rdev))
+}

--- a/fs/copy_darwinopenbsdsolaris.go
+++ b/fs/copy_darwinopenbsdsolaris.go
@@ -33,3 +33,8 @@ func copyDevice(dst string, fi os.FileInfo) error {
 	}
 	return unix.Mknod(dst, uint32(fi.Mode()), int(st.Rdev))
 }
+
+func utimesNano(name string, atime, mtime syscall.Timespec) error {
+	timespec := []syscall.Timespec{atime, mtime}
+	return syscall.UtimesNano(name, timespec)
+}

--- a/fs/copy_freebsd.go
+++ b/fs/copy_freebsd.go
@@ -1,0 +1,35 @@
+// +build freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+func copyDevice(dst string, fi os.FileInfo) error {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("unsupported stat type")
+	}
+	return unix.Mknod(dst, uint32(fi.Mode()), st.Rdev)
+}

--- a/fs/copy_freebsd.go
+++ b/fs/copy_freebsd.go
@@ -33,3 +33,10 @@ func copyDevice(dst string, fi os.FileInfo) error {
 	}
 	return unix.Mknod(dst, uint32(fi.Mode()), st.Rdev)
 }
+
+func utimesNano(name string, atime, mtime syscall.Timespec) error {
+	at := unix.NsecToTimespec(atime.Nano())
+	mt := unix.NsecToTimespec(mtime.Nano())
+	utimes := [2]unix.Timespec{at, mt}
+	return unix.UtimesNanoAt(unix.AT_FDCWD, name, utimes[0:], unix.AT_SYMLINK_NOFOLLOW)
+}

--- a/fs/copy_unix.go
+++ b/fs/copy_unix.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/containerd/continuity/sysx"
 	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
 
 func copyFileInfo(fi os.FileInfo, name string) error {
@@ -101,12 +100,4 @@ func copyXAttrs(dst, src string, xeh XAttrErrorHandler) error {
 	}
 
 	return nil
-}
-
-func copyDevice(dst string, fi os.FileInfo) error {
-	st, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		return errors.New("unsupported stat type")
-	}
-	return unix.Mknod(dst, uint32(fi.Mode()), int(st.Rdev))
 }

--- a/fs/copy_unix.go
+++ b/fs/copy_unix.go
@@ -52,8 +52,7 @@ func copyFileInfo(fi os.FileInfo, name string) error {
 		}
 	}
 
-	timespec := []syscall.Timespec{StatAtime(st), StatMtime(st)}
-	if err := syscall.UtimesNano(name, timespec); err != nil {
+	if err := utimesNano(name, StatAtime(st), StatMtime(st)); err != nil {
 		return errors.Wrapf(err, "failed to utime %s", name)
 	}
 

--- a/fs/du_cmd_freebsd_test.go
+++ b/fs/du_cmd_freebsd_test.go
@@ -1,0 +1,38 @@
+// +build freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func duCmd(root string) *exec.Cmd {
+	cmd := exec.Command("du", "-s", root)
+	/*
+		From du(1):
+		BLOCKSIZE  If the environment variable BLOCKSIZE is set, and the -h, -k,
+		           -m or --si options are not specified, the block counts will be
+		           displayed in units of that block size.  If BLOCKSIZE is not
+		           set, and the -h, -k, -m or --si options are not specified, the
+		           block counts will be displayed in 512-byte blocks.
+	*/
+	cmd.Env = []string{fmt.Sprintf("BLOCKSIZE=%d", blocksUnitSize)}
+	return cmd
+}

--- a/fs/du_cmd_unix_test.go
+++ b/fs/du_cmd_unix_test.go
@@ -1,0 +1,28 @@
+// +build !windows,!freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func duCmd(root string) *exec.Cmd {
+	return exec.Command("du", "-s", fmt.Sprintf("--block-size=%d", blocksUnitSize), root)
+}

--- a/fs/du_unix.go
+++ b/fs/du_unix.go
@@ -41,9 +41,9 @@ type inode struct {
 
 func newInode(stat *syscall.Stat_t) inode {
 	return inode{
-		// Dev is uint32 on darwin/bsd, uint64 on linux/solaris
+		// Dev is uint32 on darwin/bsd, uint64 on linux/solaris/freebsd
 		dev: uint64(stat.Dev), // nolint: unconvert
-		// Ino is uint32 on bsd, uint64 on darwin/linux/solaris
+		// Ino is uint32 on bsd, uint64 on darwin/linux/solaris/freebsd
 		ino: uint64(stat.Ino), // nolint: unconvert
 	}
 }

--- a/fs/du_unix_test.go
+++ b/fs/du_unix_test.go
@@ -19,10 +19,8 @@
 package fs
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"syscall"
@@ -80,7 +78,7 @@ func getTmpAlign() (func(int64) int64, func(int64) int64, error) {
 }
 
 func duCheck(root string) (usage int64, err error) {
-	cmd := exec.Command("du", "-s", fmt.Sprintf("--block-size=%d", blocksUnitSize), root)
+	cmd := duCmd(root)
 	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
This series of commits adds support for FreeBSD.  Aside from `TestUsage` failing on ZFS (see https://github.com/containerd/continuity/issues/172), all the tests are passing.

Some of the files are pretty awkwardly-named; if you have suggestions for changing them I'm happy to do so.

I recognize that there's no CI coverage for FreeBSD today (though adding at least cross-compiling to CI would be reasonably straightforward) and that there may not be interest in maintaining the code.  If that's the case and you prefer not to merge this, I can maintain my own usage of it on my fork.