### PR TITLE
Fix darwin issues

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,8 +12,11 @@ Darren Stahl <darst@microsoft.com>
 Derek McGowan <derek@mcg.dev>
 Derek McGowan <derek@mcgstyle.net>
 Edward Pilatowicz <edward.pilatowicz@oracle.com>
+Fu Wei <fuweid89@gmail.com>
+Hajime Tazaki <thehajime@gmail.com>
 Ian Campbell <ijc@docker.com>
 Ivan Markin <sw@nogoegst.net>
+Jacob Blain Christen <jacob@rancher.com>
 Justin Cormack <justin.cormack@docker.com>
 Justin Cummins <sul3n3t@gmail.com>
 Kasper Fabæch Brandt <poizan@poizan.dk>
@@ -23,10 +26,11 @@ Michael Crosby <michael@thepasture.io>
 Michael Wan <zirenwan@gmail.com>
 Mike Brown <brownwm@us.ibm.com>
 Niels de Vos <ndevos@redhat.com>
+Phil Estes <estesp@amazon.com>
 Phil Estes <estesp@gmail.com>
 Phil Estes <estesp@linux.vnet.ibm.com>
-Samuel Karp <me@samuelkarp.com>
 Sam Whited <sam@samwhited.com>
+Samuel Karp <me@samuelkarp.com>
 Sebastiaan van Stijn <github@gone.nl>
 Shengjing Zhu <zhsj@debian.org>
 Stephen J Day <stephen.day@docker.com>

--- a/fs/copy_darwin.go
+++ b/fs/copy_darwin.go
@@ -1,4 +1,4 @@
-// +build darwin openbsd solaris
+// +build darwin
 
 /*
    Copyright The containerd Authors.
@@ -35,6 +35,8 @@ func copyDevice(dst string, fi os.FileInfo) error {
 }
 
 func utimesNano(name string, atime, mtime syscall.Timespec) error {
-	timespec := []syscall.Timespec{atime, mtime}
-	return syscall.UtimesNano(name, timespec)
+	at := unix.NsecToTimespec(atime.Nano())
+	mt := unix.NsecToTimespec(mtime.Nano())
+	utimes := [2]unix.Timespec{at, mt}
+	return unix.UtimesNanoAt(unix.AT_FDCWD, name, utimes[0:], unix.AT_SYMLINK_NOFOLLOW)
 }

--- a/fs/copy_openbsdsolaris.go
+++ b/fs/copy_openbsdsolaris.go
@@ -1,0 +1,40 @@
+// +build openbsd solaris
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+func copyDevice(dst string, fi os.FileInfo) error {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("unsupported stat type")
+	}
+	return unix.Mknod(dst, uint32(fi.Mode()), int(st.Rdev))
+}
+
+func utimesNano(name string, atime, mtime syscall.Timespec) error {
+	timespec := []syscall.Timespec{atime, mtime}
+	return syscall.UtimesNano(name, timespec)
+}

--- a/fs/du_cmd_freebsddarwin_test.go
+++ b/fs/du_cmd_freebsddarwin_test.go
@@ -1,4 +1,4 @@
-// +build freebsd
+// +build freebsd darwin
 
 /*
    Copyright The containerd Authors.

--- a/fs/du_cmd_unix_test.go
+++ b/fs/du_cmd_unix_test.go
@@ -1,4 +1,4 @@
-// +build !windows,!freebsd
+// +build !windows,!freebsd,!darwin
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
This PR is related to https://github.com/containerd/containerd/pull/4526, which tries to support darwin runtime of containerd.

The patches contains several fixes:

- a fix to incorrect option for `du` command
```
% TMPDIR=/tmp/fs go test ./fs -v -run TestUsage
(snip)
=== CONT  TestUsage/HardlinkSparefile
    du_test.go:134: Failed calling du: exit status 64
du: illegal option -- -
usage: du [-H | -L | -P] [-a | -s | -d depth] [-c] [-h | -k | -m | -g] [-x] [-I mask] [file ...]
=== CONT  TestUsage/Hardlinks
    du_test.go:134: Failed calling du: exit status 64
(snip)
```

- utimes usage similar to FreeBSD (https://github.com/containerd/continuity/commit/bb87682d41f1a0a2fdd10fcd4eade8fc8874a06e)

As macOS is similar to FreeBSD, the fixes are actually following the way FreeBSD did, but darwin itself has slightly different internals, thus adapting those caes.

Even du command fixes, the test with TestUsage still fails with `SparseFiles`, but will address this issue later.