### PR TITLE
fix fmt.Errorf("%w", err) on err == nil

### DIFF
--- a/fs/copy_linux.go
+++ b/fs/copy_linux.go
@@ -95,7 +95,10 @@ func copyFileContent(dst, src *os.File) error {
 			buf := bufferPool.Get().(*[]byte)
 			_, err = io.CopyBuffer(dst, src, *buf)
 			bufferPool.Put(buf)
-			return fmt.Errorf("userspace copy failed: %w", err)
+			if err != nil {
+				return fmt.Errorf("userspace copy failed: %w", err)
+			}
+			return nil
 		}
 
 		first = false


### PR DESCRIPTION
When err is nil, `fmt.Errorf("....: %w", err)` should not be returned

Thanks to @simonflood for reporting this in https://github.com/rancher-sandbox/rancher-desktop/issues/771#issuecomment-942180713
