### PR TITLE
Build containerd/continuity on multiple Unix OSes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,13 +76,6 @@ jobs:
       run: make build binaries
       working-directory: src/github.com/containerd/continuity
 
-    - name: Cross-compile
-      if: startsWith(matrix.os, 'ubuntu')
-      shell: bash
-      run: |
-          GOOS=freebsd make build binaries
-      working-directory: src/github.com/containerd/continuity
-
     - name: Linux Tests
       if: startsWith(matrix.os, 'ubuntu')
       run: |
@@ -94,4 +87,37 @@ jobs:
       if: ${{ !startsWith(matrix.os, 'ubuntu') }}
       shell: bash
       run: make test-compile
+      working-directory: src/github.com/containerd/continuity
+
+  cross:
+    name: Cross-compile
+    runs-on: ubuntu-18.04
+    timeout-minutes: 10
+    needs: [project]
+
+    strategy:
+      matrix:
+        goos: [freebsd, openbsd, netbsd, darwin, solaris]
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.15
+
+    - name: Setup Go binary path
+      shell: bash
+      run: |
+        echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+        echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+        path: src/github.com/containerd/continuity
+
+    - name: Cross-compile ${{matrix.goos}}
+      shell: bash
+      run: |
+          GOOS=${{matrix.goos}} make build binaries
       working-directory: src/github.com/containerd/continuity

--- a/commands/mount_unsupported.go
+++ b/commands/mount_unsupported.go
@@ -1,5 +1,5 @@
-//go:build windows || solaris
-// +build windows solaris
+//go:build windows || solaris || openbsd || netbsd
+// +build windows solaris openbsd netbsd
 
 /*
    Copyright The containerd Authors.

--- a/continuityfs/provider.go
+++ b/continuityfs/provider.go
@@ -1,6 +1,3 @@
-//go:build linux || darwin || freebsd
-// +build linux darwin freebsd
-
 /*
    Copyright The containerd Authors.
 

--- a/devices/devices_unix.go
+++ b/devices/devices_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || darwin || freebsd || solaris
-// +build linux darwin freebsd solaris
+//go:build !windows
+// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/devices/mknod_unix.go
+++ b/devices/mknod_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || darwin || solaris
-// +build linux darwin solaris
+//go:build !(freebsd || windows)
+// +build !freebsd,!windows
 
 /*
    Copyright The containerd Authors.

--- a/driver/driver_unix.go
+++ b/driver/driver_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || darwin || freebsd || solaris
-// +build linux darwin freebsd solaris
+//go:build !windows
+// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/driver/lchmod_unix.go
+++ b/driver/lchmod_unix.go
@@ -1,5 +1,5 @@
-//go:build darwin || freebsd || solaris
-// +build darwin freebsd solaris
+//go:build darwin || freebsd || netbsd || openbsd || solaris
+// +build darwin freebsd netbsd openbsd solaris
 
 /*
    Copyright The containerd Authors.

--- a/fs/copy_darwin.go
+++ b/fs/copy_darwin.go
@@ -34,10 +34,3 @@ func copyDevice(dst string, fi os.FileInfo) error {
 	}
 	return unix.Mknod(dst, uint32(fi.Mode()), int(st.Rdev))
 }
-
-func utimesNano(name string, atime, mtime syscall.Timespec) error {
-	at := unix.NsecToTimespec(atime.Nano())
-	mt := unix.NsecToTimespec(mtime.Nano())
-	utimes := [2]unix.Timespec{at, mt}
-	return unix.UtimesNanoAt(unix.AT_FDCWD, name, utimes[0:], unix.AT_SYMLINK_NOFOLLOW)
-}

--- a/fs/copy_device_unix.go
+++ b/fs/copy_device_unix.go
@@ -1,5 +1,5 @@
-//go:build openbsd || solaris
-// +build openbsd solaris
+//go:build openbsd || solaris || netbsd
+// +build openbsd solaris netbsd
 
 /*
    Copyright The containerd Authors.
@@ -33,9 +33,4 @@ func copyDevice(dst string, fi os.FileInfo) error {
 		return errors.New("unsupported stat type")
 	}
 	return unix.Mknod(dst, uint32(fi.Mode()), int(st.Rdev))
-}
-
-func utimesNano(name string, atime, mtime syscall.Timespec) error {
-	timespec := []syscall.Timespec{atime, mtime}
-	return syscall.UtimesNano(name, timespec)
 }

--- a/fs/copy_freebsd.go
+++ b/fs/copy_freebsd.go
@@ -34,10 +34,3 @@ func copyDevice(dst string, fi os.FileInfo) error {
 	}
 	return unix.Mknod(dst, uint32(fi.Mode()), st.Rdev)
 }
-
-func utimesNano(name string, atime, mtime syscall.Timespec) error {
-	at := unix.NsecToTimespec(atime.Nano())
-	mt := unix.NsecToTimespec(mtime.Nano())
-	utimes := [2]unix.Timespec{at, mt}
-	return unix.UtimesNanoAt(unix.AT_FDCWD, name, utimes[0:], unix.AT_SYMLINK_NOFOLLOW)
-}

--- a/fs/copy_unix.go
+++ b/fs/copy_unix.go
@@ -1,5 +1,5 @@
-//go:build darwin || freebsd || openbsd || solaris
-// +build darwin freebsd openbsd solaris
+//go:build darwin || freebsd || openbsd || netbsd || solaris
+// +build darwin freebsd openbsd netbsd solaris
 
 /*
    Copyright The containerd Authors.

--- a/fs/stat_atim.go
+++ b/fs/stat_atim.go
@@ -1,0 +1,45 @@
+//go:build linux || openbsd || solaris
+// +build linux openbsd solaris
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"syscall"
+	"time"
+)
+
+// StatAtime returns the Atim
+func StatAtime(st *syscall.Stat_t) syscall.Timespec {
+	return st.Atim
+}
+
+// StatCtime returns the Ctim
+func StatCtime(st *syscall.Stat_t) syscall.Timespec {
+	return st.Ctim
+}
+
+// StatMtime returns the Mtim
+func StatMtime(st *syscall.Stat_t) syscall.Timespec {
+	return st.Mtim
+}
+
+// StatATimeAsTime returns st.Atim as a time.Time
+func StatATimeAsTime(st *syscall.Stat_t) time.Time {
+	return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) //nolint: unconvert // int64 conversions ensure the line compiles for 32-bit systems as well.
+}

--- a/hardlinks_unix.go
+++ b/hardlinks_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || darwin || freebsd || solaris
-// +build linux darwin freebsd solaris
+//go:build !windows
+// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/resource_unix.go
+++ b/resource_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || darwin || freebsd || solaris
-// +build linux darwin freebsd solaris
+//go:build !windows
+// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/sysx/nodata_unix.go
+++ b/sysx/nodata_unix.go
@@ -1,5 +1,5 @@
-//go:build darwin || freebsd || openbsd
-// +build darwin freebsd openbsd
+//go:build !(linux || solaris || windows)
+// +build !linux,!solaris,!windows
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
While the .go files have multiple build tags, they haven't been tested on
GitHub Actions except for FreeBSD.

This change also fixes #183.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>