### PR TITLE
Do not log errors before returning them

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -19,7 +19,6 @@ package continuity
 import (
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"sort"
 
@@ -92,8 +91,7 @@ func BuildManifest(ctx Context) (*Manifest, error) {
 			if err == ErrNotFound {
 				return nil
 			}
-			log.Printf("error getting resource %q: %v", p, err)
-			return err
+			return fmt.Errorf("failed to get resource %q: %w", p, err)
 		}
 
 		// add to the hardlink manager


### PR DESCRIPTION
Except for one case, all logs are ultimately returned to the callers.
Fixes #179.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>