### PR TITLE
fs: use syscall.Timespec.Unix

### DIFF
--- a/fs/stat_atim.go
+++ b/fs/stat_atim.go
@@ -41,5 +41,5 @@ func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 
 // StatATimeAsTime returns st.Atim as a time.Time
 func StatATimeAsTime(st *syscall.Stat_t) time.Time {
-	return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) //nolint: unconvert // int64 conversions ensure the line compiles for 32-bit systems as well.
+	return time.Unix(st.Atim.Unix())
 }

--- a/fs/stat_darwinbsd.go
+++ b/fs/stat_darwinbsd.go
@@ -41,5 +41,5 @@ func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 
 // StatATimeAsTime returns the access time as a time.Time
 func StatATimeAsTime(st *syscall.Stat_t) time.Time {
-	return time.Unix(int64(st.Atimespec.Sec), int64(st.Atimespec.Nsec)) //nolint: unconvert // int64 conversions ensure the line compiles for 32-bit systems as well.
+	return time.Unix(st.Atimespec.Unix())
 }


### PR DESCRIPTION
Use the syscall method instead of repeating the type conversions for
the syscall.Stat_t Atim/Atimespec members. This also allows to drop the
//nolint: unconvert comments.