### PR TITLE
Fix wrapping errors

### DIFF
--- a/context.go
+++ b/context.go
@@ -390,7 +390,7 @@ func (c *context) checkoutFile(fp string, rf RegularFile) error {
 		}
 	}
 	if err != nil {
-		return fmt.Errorf("file content could not be provided: %v", err)
+		return fmt.Errorf("file content could not be provided: %w", err)
 	}
 	defer r.Close()
 
@@ -422,7 +422,7 @@ func (c *context) Apply(resource Resource) error {
 	case RegularFile:
 		if fi == nil {
 			if err := c.checkoutFile(fp, r); err != nil {
-				return fmt.Errorf("error checking out file %q: %v", resource.Path(), err)
+				return fmt.Errorf("error checking out file %q: %w", resource.Path(), err)
 			}
 			chmod = false
 		} else {
@@ -431,18 +431,18 @@ func (c *context) Apply(resource Resource) error {
 			}
 			if fi.Size() != r.Size() {
 				if err := c.checkoutFile(fp, r); err != nil {
-					return fmt.Errorf("error checking out file %q: %v", resource.Path(), err)
+					return fmt.Errorf("error checking out file %q: %w", resource.Path(), err)
 				}
 			} else {
 				for _, dgst := range r.Digests() {
 					f, err := os.Open(fp)
 					if err != nil {
-						return fmt.Errorf("failure opening file for read %q: %v", resource.Path(), err)
+						return fmt.Errorf("failure opening file for read %q: %w", resource.Path(), err)
 					}
 					compared, err := dgst.Algorithm().FromReader(f)
 					if err == nil && dgst != compared {
 						if err := c.checkoutFile(fp, r); err != nil {
-							return fmt.Errorf("error checking out file %q: %v", resource.Path(), err)
+							return fmt.Errorf("error checking out file %q: %w", resource.Path(), err)
 						}
 						break
 					}
@@ -450,7 +450,7 @@ func (c *context) Apply(resource Resource) error {
 						err = err1
 					}
 					if err != nil {
-						return fmt.Errorf("error checking digest for %q: %v", resource.Path(), err)
+						return fmt.Errorf("error checking digest for %q: %w", resource.Path(), err)
 					}
 				}
 			}

--- a/driver/driver_unix.go
+++ b/driver/driver_unix.go
@@ -54,7 +54,7 @@ func (d *driver) Mkfifo(path string, mode os.FileMode) error {
 func (d *driver) Getxattr(p string) (map[string][]byte, error) {
 	xattrs, err := sysx.Listxattr(p)
 	if err != nil {
-		return nil, fmt.Errorf("listing %s xattrs: %v", p, err)
+		return nil, fmt.Errorf("listing %s xattrs: %w", p, err)
 	}
 
 	sort.Strings(xattrs)
@@ -63,7 +63,7 @@ func (d *driver) Getxattr(p string) (map[string][]byte, error) {
 	for _, attr := range xattrs {
 		value, err := sysx.Getxattr(p, attr)
 		if err != nil {
-			return nil, fmt.Errorf("getting %q xattr on %s: %v", attr, p, err)
+			return nil, fmt.Errorf("getting %q xattr on %s: %w", attr, p, err)
 		}
 
 		// NOTE(stevvooe): This append/copy tricky relies on unique
@@ -82,7 +82,7 @@ func (d *driver) Getxattr(p string) (map[string][]byte, error) {
 func (d *driver) Setxattr(path string, attrMap map[string][]byte) error {
 	for attr, value := range attrMap {
 		if err := sysx.Setxattr(path, attr, value, 0); err != nil {
-			return fmt.Errorf("error setting xattr %q on %s: %v", attr, path, err)
+			return fmt.Errorf("error setting xattr %q on %s: %w", attr, path, err)
 		}
 	}
 
@@ -94,7 +94,7 @@ func (d *driver) Setxattr(path string, attrMap map[string][]byte) error {
 func (d *driver) LGetxattr(p string) (map[string][]byte, error) {
 	xattrs, err := sysx.LListxattr(p)
 	if err != nil {
-		return nil, fmt.Errorf("listing %s xattrs: %v", p, err)
+		return nil, fmt.Errorf("listing %s xattrs: %w", p, err)
 	}
 
 	sort.Strings(xattrs)
@@ -103,7 +103,7 @@ func (d *driver) LGetxattr(p string) (map[string][]byte, error) {
 	for _, attr := range xattrs {
 		value, err := sysx.LGetxattr(p, attr)
 		if err != nil {
-			return nil, fmt.Errorf("getting %q xattr on %s: %v", attr, p, err)
+			return nil, fmt.Errorf("getting %q xattr on %s: %w", attr, p, err)
 		}
 
 		// NOTE(stevvooe): This append/copy tricky relies on unique
@@ -122,7 +122,7 @@ func (d *driver) LGetxattr(p string) (map[string][]byte, error) {
 func (d *driver) LSetxattr(path string, attrMap map[string][]byte) error {
 	for attr, value := range attrMap {
 		if err := sysx.LSetxattr(path, attr, value, 0); err != nil {
-			return fmt.Errorf("error setting xattr %q on %s: %v", attr, path, err)
+			return fmt.Errorf("error setting xattr %q on %s: %w", attr, path, err)
 		}
 	}
 

--- a/fs/copy.go
+++ b/fs/copy.go
@@ -158,7 +158,9 @@ func copyDirectory(dst, src string, inodes map[uint64]string, o *copyDirOpts) er
 			}
 		default:
 			// TODO: Support pipes and sockets
-			return fmt.Errorf("unsupported mode %s: %w", fi.Mode(), err)
+			if err != nil {
+				return fmt.Errorf("unsupported mode %s: %w", fi.Mode(), err)
+			}
 		}
 
 		if err := copyFileInfo(fi, source, target); err != nil {

--- a/hardlinks.go
+++ b/hardlinks.go
@@ -63,7 +63,7 @@ func (hlm *hardlinkManager) Merge() ([]Resource, error) {
 
 		merged, err := Merge(linked...)
 		if err != nil {
-			return nil, fmt.Errorf("error merging hardlink: %v", err)
+			return nil, fmt.Errorf("error merging hardlink: %w", err)
 		}
 
 		resources = append(resources, merged)

--- a/manifest.go
+++ b/manifest.go
@@ -78,7 +78,7 @@ func BuildManifest(ctx Context) (*Manifest, error) {
 
 	if err := ctx.Walk(func(p string, fi os.FileInfo, err error) error {
 		if err != nil {
-			return fmt.Errorf("error walking %s: %v", p, err)
+			return fmt.Errorf("error walking %s: %w", p, err)
 		}
 
 		if p == string(os.PathSeparator) {
@@ -101,7 +101,7 @@ func BuildManifest(ctx Context) (*Manifest, error) {
 			return nil
 		} else if err != errNotAHardLink {
 			// handle any other case where we have a proper error.
-			return fmt.Errorf("adding hardlink %s: %v", p, err)
+			return fmt.Errorf("adding hardlink %s: %w", p, err)
 		}
 
 		resourcesByPath[p] = resource


### PR DESCRIPTION
- `fmt.Errorf: use %w, not %v to wrap errors`
- `fs: fix wrapping nil err`

Follow-up to:
- https://github.com/containerd/continuity/pull/185
- https://github.com/containerd/continuity/pull/187