### PR TITLE
Correctly ignore error wrapping `ErrNotSupported`

### DIFF
--- a/context.go
+++ b/context.go
@@ -18,6 +18,7 @@ package continuity
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -151,7 +152,7 @@ func (c *context) Resource(p string, fi os.FileInfo) (Resource, error) {
 	}
 
 	base.xattrs, err = c.resolveXAttrs(fp, fi, base)
-	if err != nil && err != ErrNotSupported {
+	if err != nil && !errors.Is(err, ErrNotSupported) {
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes: #206

This change fixes some existing tests which were failing on WIndows:
```
--- FAIL: TestCopyDirectory (0.03s)
    copy_test.go:45: Copy test failed: failed to build manifest: failed to get resource "\\etc": xattr extraction is not supported: not supported
--- FAIL: TestCopyDirectoryWithLocalSymlink (0.01s)
    copy_test.go:59: Copy test failed: failed to build manifest: failed to get resource "\\link-no-nothing.txt": xattr extraction for symlinks is not supported: not supported
--- FAIL: TestCopyWithLargeFile (9.17s)
    copy_test.go:74: failed to build manifest: failed to get resource "\\banana": xattr extraction is not supported: not supported
```

The same issue was visible with the command-line tool
```
> .\continuity.exe build . > ../a.pb
2022/08/11 02:15:44 error generating manifest: failed to get resource "\\.git": xattr extraction is not supported: not supported
```
now looks like
```
> .\continuity.exe build . > ../a.pb
```