### PR TITLE
Allow Walk to visit volume mounts on Windows

### DIFF
--- a/pathdriver/path_driver.go
+++ b/pathdriver/path_driver.go
@@ -17,7 +17,12 @@
 package pathdriver
 
 import (
+	"errors"
 	"path/filepath"
+)
+
+var (
+	ErrPathRecursion = errors.New("path recursion")
 )
 
 // PathDriver provides all of the path manipulation functions in a common
@@ -79,13 +84,6 @@ func (*pathDriver) Separator() byte {
 
 func (*pathDriver) Abs(path string) (string, error) {
 	return filepath.Abs(path)
-}
-
-// Note that filepath.Walk calls os.Stat, so if the context wants to
-// to call Driver.Stat() for Walk, they need to create a new struct that
-// overrides this method.
-func (*pathDriver) Walk(root string, walkFn filepath.WalkFunc) error {
-	return filepath.Walk(root, walkFn)
 }
 
 func (*pathDriver) FromSlash(path string) string {

--- a/pathdriver/path_driver_unix.go
+++ b/pathdriver/path_driver_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package pathdriver
+
+import "path/filepath"
+
+// Note that filepath.Walk calls os.Stat, so if the context wants to
+// to call Driver.Stat() for Walk, they need to create a new struct that
+// overrides this method.
+func (*pathDriver) Walk(root string, walkFn filepath.WalkFunc) error {
+	return filepath.Walk(root, walkFn)
+}

--- a/pathdriver/path_driver_windows.go
+++ b/pathdriver/path_driver_windows.go
@@ -1,0 +1,220 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package pathdriver
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"syscall"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// walker is a copy of the standard package filepath.Walk implementation along
+// with helper functions, modified to allow visiting folder mounted volumes on Windows.
+// Mounting a volume inside a folder is supported on Windows via NTFS reparse points.
+// Reparse points allow extending NTFS functionality via a so called filter driver.
+// By default, ntfs ships with a number of filter drivers for symlinks (similar to
+// symlinks for files on Linux), volume mounts (similar to mounts on Windows),
+// directory junction points (similar to bind mounts on Linux), Unix domain sockets
+// (https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/).
+//
+// Currently go does not walk inside mounted folder, because it treats all reparse points
+// as symlinks. See:
+// https://go-review.googlesource.com/c/go/+/41830/
+//
+// The short explanation is that FileMode does not have ModeDir set for any path that also
+// has ModeSymlink. ModeSymlink is set on any junction, volume mounts included.
+//
+// Proper recursion detection in dependent code would have been preferable, along with a
+// clear distinction between reparse point types. Until that happens, we need to implement
+// this outside of go.
+//
+// Curretly, this only implements walking into volume mounts, as we only care about those
+// at this point. Walking into directory junctions can also be added later, if needed.
+type walker struct {
+	// volumeToPath holds a mapping between volumes, and paths that we have visited,
+	// in which those volumes are mounted. This is used to prevent recursion when
+	// walking mounted volumes.
+	volumeToPath map[string]string
+}
+
+// walk walks the file tree rooted at root, calling fn for each file or
+// directory in the tree, including root.
+//
+// All errors that arise visiting files and directories are filtered by fn:
+// see the WalkFunc documentation for details.
+//
+// The files are walked in lexical order, which makes the output deterministic
+// but requires Walk to read an entire directory into memory before proceeding
+// to walk that directory.
+//
+// Walk does not follow symbolic links.
+//
+// Walk is less efficient than WalkDir, introduced in Go 1.16,
+// which avoids calling os.Lstat on every visited file or directory.
+func walk(root string, fn filepath.WalkFunc) error {
+	w := walker{
+		volumeToPath: map[string]string{},
+	}
+	info, err := os.Lstat(root)
+	if err != nil {
+		err = fn(root, nil, err)
+	} else {
+		err = w.walk(root, info, fn)
+	}
+	if err == filepath.SkipDir {
+		return nil
+	}
+	return err
+}
+
+func (w *walker) walk(path string, info fs.FileInfo, walkFn filepath.WalkFunc) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		tgt, err := getReparsePoint(path, info)
+		if err != nil {
+			return err
+		}
+
+		if !tgt.IsMountPoint {
+			return walkFn(path, info, nil)
+		}
+
+		pth := w.volumeToPath[tgt.Target]
+		if pth != "" {
+			// This junction was already visited and is one of our parent folders.
+			// Send this path to walkFn with an error that denotes a recursion. Allow
+			// walkFn to handle the case.
+			return walkFn(path, info, fmt.Errorf("%s was already visited: %w", path, ErrPathRecursion))
+		}
+
+		// record the volume and the mount point. This will allow us to
+		// prevent a recursion if the same volume is mounted again somewhere deeper
+		// into our path.
+		w.volumeToPath[tgt.Target] = path
+
+		// Remove this volume from the map once we finish walking it.
+		// This will allow us to walk it again if it's mounted in another
+		// folder, without triggering a recursion.
+		defer delete(w.volumeToPath, tgt.Target)
+	} else {
+		if !info.IsDir() {
+			return walkFn(path, info, nil)
+		}
+	}
+
+	names, err := w.readDirNames(path)
+	err1 := walkFn(path, info, err)
+	// If err != nil, walk can't walk into this directory.
+	// err1 != nil means walkFn want walk to skip this directory or stop walking.
+	// Therefore, if one of err and err1 isn't nil, walk will return.
+	if err != nil || err1 != nil {
+		// The caller's behavior is controlled by the return value, which is decided
+		// by walkFn. walkFn may ignore err and return nil.
+		// If walkFn returns SkipDir, it will be handled by the caller.
+		// So walk should return whatever walkFn returns.
+		return err1
+	}
+
+	for _, name := range names {
+		filename := filepath.Join(path, name)
+		fileInfo, err := os.Lstat(filename)
+		if err != nil {
+			if err := walkFn(filename, fileInfo, err); err != nil && err != filepath.SkipDir {
+				return err
+			}
+		} else {
+			err = w.walk(filename, fileInfo, walkFn)
+			if err != nil {
+				if !fileInfo.IsDir() || err != filepath.SkipDir {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (w *walker) readDirNames(dirname string) ([]string, error) {
+	f, err := os.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+	names, err := f.Readdirnames(-1)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func getFileHandle(path string, info fs.FileInfo) (syscall.Handle, error) {
+	p, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	attrs := uint32(syscall.FILE_FLAG_BACKUP_SEMANTICS)
+	if info.Mode()&fs.ModeSymlink != 0 {
+		// Use FILE_FLAG_OPEN_REPARSE_POINT, otherwise CreateFile will follow symlink.
+		// See https://docs.microsoft.com/en-us/windows/desktop/FileIO/symbolic-link-effects-on-file-systems-functions#createfile-and-createfiletransacted
+		attrs |= syscall.FILE_FLAG_OPEN_REPARSE_POINT
+	}
+	h, err := syscall.CreateFile(p, 0, 0, nil, syscall.OPEN_EXISTING, attrs, 0)
+	if err != nil {
+		return 0, err
+	}
+	return h, nil
+}
+
+func readlink(path string, info fs.FileInfo) ([]byte, error) {
+	h, err := getFileHandle(path, info)
+	if err != nil {
+		return nil, err
+	}
+	defer syscall.CloseHandle(h)
+
+	rdbbuf := make([]byte, syscall.MAXIMUM_REPARSE_DATA_BUFFER_SIZE)
+	var bytesReturned uint32
+	err = syscall.DeviceIoControl(h, syscall.FSCTL_GET_REPARSE_POINT, nil, 0, &rdbbuf[0], uint32(len(rdbbuf)), &bytesReturned, nil)
+	if err != nil {
+		return nil, err
+	}
+	return rdbbuf[:bytesReturned], nil
+}
+
+func getReparsePoint(path string, info fs.FileInfo) (*winio.ReparsePoint, error) {
+	target, err := readlink(path, info)
+	if err != nil {
+		return nil, err
+	}
+	rp, err := winio.DecodeReparsePoint(target)
+	if err != nil {
+		return nil, err
+	}
+	return rp, nil
+}
+
+// Note that filepath.Walk calls os.Stat, so if the context wants to
+// to call Driver.Stat() for Walk, they need to create a new struct that
+// overrides this method.
+func (*pathDriver) Walk(root string, walkFn filepath.WalkFunc) error {
+	return walk(root, walkFn)
+}

--- a/pathdriver/path_driver_windows_test.go
+++ b/pathdriver/path_driver_windows_test.go
@@ -1,0 +1,180 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package pathdriver
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestWalk(t *testing.T) {
+	walk := func(root string, fn fs.WalkDirFunc) error {
+		return LocalPathDriver.Walk(root, func(path string, info fs.FileInfo, err error) error {
+			return fn(path, &statDirEntry{info}, err)
+		})
+	}
+	testWalk(t, walk, 1)
+}
+
+type Node struct {
+	name    string
+	entries []*Node // nil if the entry is a file
+	mark    int
+}
+
+var tree = &Node{
+	"testdata",
+	[]*Node{
+		{"a", nil, 0},
+		{"b", []*Node{}, 0},
+		{"c", nil, 0},
+		{
+			"d",
+			[]*Node{
+				{"x", nil, 0},
+				{"y", []*Node{}, 0},
+				{
+					"z",
+					[]*Node{
+						{"u", nil, 0},
+						{"v", nil, 0},
+					},
+					0,
+				},
+			},
+			0,
+		},
+	},
+	0,
+}
+
+// Assumes that each node name is unique. Good enough for a test.
+// If clear is true, any incoming error is cleared before return. The errors
+// are always accumulated, though.
+func mark(d fs.DirEntry, err error, errors *[]error, clear bool) error {
+	name := d.Name()
+	walkTree(tree, tree.name, func(path string, n *Node) {
+		if n.name == name {
+			n.mark++
+		}
+	})
+	if err != nil {
+		*errors = append(*errors, err)
+		if clear {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func checkMarks(t *testing.T, report bool) {
+	walkTree(tree, tree.name, func(path string, n *Node) {
+		if n.mark != 1 && report {
+			t.Errorf("node %s mark = %d; expected 1", path, n.mark)
+		}
+		n.mark = 0
+	})
+}
+
+type statDirEntry struct {
+	info fs.FileInfo
+}
+
+func (d *statDirEntry) Name() string               { return d.info.Name() }
+func (d *statDirEntry) IsDir() bool                { return d.info.IsDir() }
+func (d *statDirEntry) Type() fs.FileMode          { return d.info.Mode().Type() }
+func (d *statDirEntry) Info() (fs.FileInfo, error) { return d.info, nil }
+
+func chtmpdir(t *testing.T) (restore func()) {
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("chtmpdir: %v", err)
+	}
+	d, err := os.MkdirTemp("", "test")
+	if err != nil {
+		t.Fatalf("chtmpdir: %v", err)
+	}
+	if err := os.Chdir(d); err != nil {
+		t.Fatalf("chtmpdir: %v", err)
+	}
+	return func() {
+		if err := os.Chdir(oldwd); err != nil {
+			t.Fatalf("chtmpdir: %v", err)
+		}
+		os.RemoveAll(d)
+	}
+}
+
+func walkTree(n *Node, path string, f func(path string, n *Node)) {
+	f(path, n)
+	for _, e := range n.entries {
+		walkTree(e, filepath.Join(path, e.name), f)
+	}
+}
+
+func makeTree(t *testing.T) {
+	walkTree(tree, tree.name, func(path string, n *Node) {
+		if n.entries == nil {
+			fd, err := os.Create(path)
+			if err != nil {
+				t.Errorf("makeTree: %v", err)
+				return
+			}
+			fd.Close()
+		} else {
+			os.Mkdir(path, 0770)
+		}
+	})
+}
+
+func testWalk(t *testing.T, walk func(string, fs.WalkDirFunc) error, errVisit int) {
+	if runtime.GOOS == "ios" {
+		restore := chtmpdir(t)
+		defer restore()
+	}
+
+	tmpDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("finding working dir:", err)
+	}
+	if err = os.Chdir(tmpDir); err != nil {
+		t.Fatal("entering temp dir:", err)
+	}
+	defer os.Chdir(origDir)
+
+	makeTree(t)
+	errors := make([]error, 0, 10)
+	clear := true
+	markFn := func(path string, d fs.DirEntry, err error) error {
+		return mark(d, err, &errors, clear)
+	}
+	// Expect no errors.
+	err = walk(tree.name, markFn)
+	if err != nil {
+		t.Fatalf("no error expected, found: %s", err)
+	}
+	if len(errors) != 0 {
+		t.Fatalf("unexpected errors: %s", errors)
+	}
+	checkMarks(t, true)
+}


### PR DESCRIPTION
This change adds a fork of the filepath.Walk function from the standard library, with changes that allows it to visit reparse points that are in fact volume mounts.

Currently go makes no distinction between a symlink, directory junction, volume mount or Unix domain socket. All reparse points are regarded as symlinks. This means that FileMode does not have ModeDir set for any path that also has ModeSymlink. This includes volume mounts. See: https://go-review.googlesource.com/c/go/+/41830/

This implementation also attempts to avoid recursions. I am on the fence about the added ```ErrPathRecursion```. The idea is to raise an error if a recursion is detected and allow the ```walkFn``` function to handle that specific error. But I am not sure what the idiomatic way to handle this, is. Any suggestions are welcome.

The current test is a copy of the test from the standard library. I am looking into adding an additional test to check the volume mount specific code and recursion prevention, but that requires mounting a volume somewhere and attempting to walk it. I am unsure how this scenario would easily be set up. Locally, I created a VHDx, attached it to the system, created a partition, formatted it and then mounted it. But this requires some powershell commandlets to be available, or at least the windows provider to handle VHDx disks.

This change should remove the need to resort to workarounds like these: https://github.com/containerd/containerd/pull/4419/commits/100624ba59f76fd771a81dd38b088b1ed66d44b8 on Windows. See https://github.com/containerd/containerd/pull/4419 for details regarding the need for this.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>