### PR TITLE
format code with gofumpt

### DIFF
--- a/cmd/continuity/commands/ls.go
+++ b/cmd/continuity/commands/ls.go
@@ -50,7 +50,6 @@ var LSCmd = &cobra.Command{
 					//nolint:unconvert
 					fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", os.FileMode(entry.Mode), entry.User, entry.Group, humanize.Bytes(uint64(entry.Size)), path)
 				}
-
 			}
 		}
 

--- a/cmd/continuity/commands/stats.go
+++ b/cmd/continuity/commands/stats.go
@@ -25,50 +25,48 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	StatsCmd = &cobra.Command{
-		Use:   "stats <manifest>",
-		Short: "display statistics about the specified manifest",
-		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 1 {
-				log.Fatalln("please specify a manifest")
+var StatsCmd = &cobra.Command{
+	Use:   "stats <manifest>",
+	Short: "display statistics about the specified manifest",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 1 {
+			log.Fatalln("please specify a manifest")
+		}
+
+		bm, err := readManifestFile(args[0])
+		if err != nil {
+			log.Fatalf("error reading manifest: %v", err)
+		}
+
+		var stats struct {
+			resources   int
+			files       int
+			directories int
+			totalSize   int64
+			symlinks    int
+		}
+
+		for _, entry := range bm.Resource {
+			stats.resources++
+			stats.totalSize += int64(entry.Size)
+
+			mode := os.FileMode(entry.Mode)
+			if mode.IsRegular() {
+				stats.files += len(entry.Path) // count hardlinks!
+			} else if mode.IsDir() {
+				stats.directories++
+			} else if mode&os.ModeSymlink != 0 {
+				stats.symlinks++
 			}
+		}
 
-			bm, err := readManifestFile(args[0])
-			if err != nil {
-				log.Fatalf("error reading manifest: %v", err)
-			}
+		w := newTabwriter(os.Stdout)
+		defer w.Flush()
 
-			var stats struct {
-				resources   int
-				files       int
-				directories int
-				totalSize   int64
-				symlinks    int
-			}
-
-			for _, entry := range bm.Resource {
-				stats.resources++
-				stats.totalSize += int64(entry.Size)
-
-				mode := os.FileMode(entry.Mode)
-				if mode.IsRegular() {
-					stats.files += len(entry.Path) // count hardlinks!
-				} else if mode.IsDir() {
-					stats.directories++
-				} else if mode&os.ModeSymlink != 0 {
-					stats.symlinks++
-				}
-			}
-
-			w := newTabwriter(os.Stdout)
-			defer w.Flush()
-
-			fmt.Fprintf(w, "resources\t%v\n", stats.resources)
-			fmt.Fprintf(w, "directories\t%v\n", stats.directories)
-			fmt.Fprintf(w, "files\t%v\n", stats.files)
-			fmt.Fprintf(w, "symlinks\t%v\n", stats.symlinks)
-			fmt.Fprintf(w, "size\t%v\n", humanize.Bytes(uint64(stats.totalSize)))
-		},
-	}
-)
+		fmt.Fprintf(w, "resources\t%v\n", stats.resources)
+		fmt.Fprintf(w, "directories\t%v\n", stats.directories)
+		fmt.Fprintf(w, "files\t%v\n", stats.files)
+		fmt.Fprintf(w, "symlinks\t%v\n", stats.symlinks)
+		fmt.Fprintf(w, "size\t%v\n", humanize.Bytes(uint64(stats.totalSize)))
+	},
+}

--- a/cmd/continuity/continuityfs/fuse.go
+++ b/cmd/continuity/continuityfs/fuse.go
@@ -99,7 +99,6 @@ func (f *File) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenR
 	return &fileHandler{
 		reader: r,
 	}, nil
-
 }
 
 func (f *File) getDirent(name string) (fuse.Dirent, error) {
@@ -171,7 +170,7 @@ type Dir struct {
 // Attr sets the fuse attributes for the directory
 func (d *Dir) Attr(ctx context.Context, attr *fuse.Attr) (err error) {
 	if d.resource == nil {
-		attr.Mode = os.ModeDir | 0555
+		attr.Mode = os.ModeDir | 0o555
 	} else {
 		attr.Mode = d.resource.Mode()
 	}
@@ -239,9 +238,7 @@ func NewDir(inode uint64, provider FileContentProvider) *Dir {
 	}
 }
 
-var (
-	rootPath = fmt.Sprintf("%c", filepath.Separator)
-)
+var rootPath = fmt.Sprintf("%c", filepath.Separator)
 
 func addNode(path string, node fs.Node, cache map[string]*Dir, provider FileContentProvider) {
 	dirPath, file := filepath.Split(path)
@@ -310,7 +307,6 @@ func NewFSFromManifest(manifest *continuity.Manifest, mountRoot string, provider
 			return nil, err
 		}
 		if rf, ok := resource.(continuity.RegularFile); ok {
-
 			for _, p := range rf.Paths() {
 				addNode(p, f, dirCache, provider)
 			}

--- a/context.go
+++ b/context.go
@@ -411,7 +411,7 @@ func (c *context) Apply(resource Resource) error {
 		return fmt.Errorf("resource %v escapes root", resource)
 	}
 
-	var chmod = true
+	chmod := true
 	fi, err := c.driver.Lstat(fp)
 	if err != nil {
 		if !os.IsNotExist(err) {

--- a/fs/copy_test.go
+++ b/fs/copy_test.go
@@ -32,13 +32,13 @@ import (
 
 func TestCopyDirectory(t *testing.T) {
 	apply := fstest.Apply(
-		fstest.CreateDir("/etc/", 0755),
-		fstest.CreateFile("/etc/hosts", []byte("localhost 127.0.0.1"), 0644),
+		fstest.CreateDir("/etc/", 0o755),
+		fstest.CreateFile("/etc/hosts", []byte("localhost 127.0.0.1"), 0o644),
 		fstest.Link("/etc/hosts", "/etc/hosts.allow"),
-		fstest.CreateDir("/usr/local/lib", 0755),
-		fstest.CreateFile("/usr/local/lib/libnothing.so", []byte{0x00, 0x00}, 0755),
+		fstest.CreateDir("/usr/local/lib", 0o755),
+		fstest.CreateFile("/usr/local/lib/libnothing.so", []byte{0x00, 0x00}, 0o755),
 		fstest.Symlink("libnothing.so", "/usr/local/lib/libnothing.so.2"),
-		fstest.CreateDir("/home", 0755),
+		fstest.CreateDir("/home", 0o755),
 	)
 
 	if err := testCopy(t, apply); err != nil {
@@ -51,7 +51,7 @@ func TestCopyDirectory(t *testing.T) {
 // fail.
 func TestCopyDirectoryWithLocalSymlink(t *testing.T) {
 	apply := fstest.Apply(
-		fstest.CreateFile("nothing.txt", []byte{0x00, 0x00}, 0755),
+		fstest.CreateFile("nothing.txt", []byte{0x00, 0x00}, 0o755),
 		fstest.Symlink("nothing.txt", "link-no-nothing.txt"),
 	)
 
@@ -66,8 +66,8 @@ func TestCopyWithLargeFile(t *testing.T) {
 		t.SkipNow()
 	}
 	apply := fstest.Apply(
-		fstest.CreateDir("/banana", 0755),
-		fstest.CreateRandomFile("/banana/split", time.Now().UnixNano(), 3*1024*1024*1024, 0644),
+		fstest.CreateDir("/banana", 0o755),
+		fstest.CreateRandomFile("/banana/split", time.Now().UnixNano(), 3*1024*1024*1024, 0o644),
 	)
 
 	if err := testCopy(t, apply); err != nil {

--- a/fs/copy_unix_test.go
+++ b/fs/copy_unix_test.go
@@ -80,22 +80,22 @@ func TestCopyIrregular(t *testing.T) {
 	var prepared int
 	prepareSrc := func(src string) {
 		f0Pipe := filepath.Join(src, "f0.pipe")
-		if err := unix.Mkfifo(f0Pipe, 0600); err != nil {
+		if err := unix.Mkfifo(f0Pipe, 0o600); err != nil {
 			t.Fatal(err)
 		}
 		prepared++
 		f1Normal := filepath.Join(src, "f1.normal")
-		if err := os.WriteFile(f1Normal, []byte("content of f1.normal"), 0600); err != nil {
+		if err := os.WriteFile(f1Normal, []byte("content of f1.normal"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		prepared++
 		f2Socket := filepath.Join(src, "f2.sock")
-		if err := unix.Mknod(f2Socket, 0600|unix.S_IFSOCK, 0); err != nil {
+		if err := unix.Mknod(f2Socket, 0o600|unix.S_IFSOCK, 0); err != nil {
 			t.Fatal(err)
 		}
 		prepared++
 		f3Dev := filepath.Join(src, "f3.dev")
-		if err := unix.Mknod(f3Dev, 0600|unix.S_IFCHR, 42); err != nil {
+		if err := unix.Mknod(f3Dev, 0o600|unix.S_IFCHR, 42); err != nil {
 			t.Logf("skipping testing S_IFCHR: %v", err)
 		} else {
 			prepared++

--- a/fs/copy_windows.go
+++ b/fs/copy_windows.go
@@ -49,7 +49,6 @@ func copyFileInfo(fi os.FileInfo, src, name string) error {
 	secInfo, err := windows.GetNamedSecurityInfo(
 		src, windows.SE_FILE_OBJECT,
 		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
-
 	if err != nil {
 		return err
 	}
@@ -68,7 +67,6 @@ func copyFileInfo(fi os.FileInfo, src, name string) error {
 		name, windows.SE_FILE_OBJECT,
 		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION,
 		sid, nil, dacl, nil); err != nil {
-
 		return err
 	}
 	return nil

--- a/fs/diff.go
+++ b/fs/diff.go
@@ -80,12 +80,13 @@ type ChangeFunc func(ChangeKind, string, os.FileInfo, error) error
 //
 // The change callback is called by the order of path names and
 // should be appliable in that order.
-//  Due to this apply ordering, the following is true
-//  - Removed directory trees only create a single change for the root
-//    directory removed. Remaining changes are implied.
-//  - A directory which is modified to become a file will not have
-//    delete entries for sub-path items, their removal is implied
-//    by the removal of the parent directory.
+//
+//	Due to this apply ordering, the following is true
+//	- Removed directory trees only create a single change for the root
+//	  directory removed. Remaining changes are implied.
+//	- A directory which is modified to become a file will not have
+//	  delete entries for sub-path items, their removal is implied
+//	  by the removal of the parent directory.
 //
 // Opaque directories will not be treated specially and each file
 // removed from the base directory will show up as a removal.

--- a/fs/diff_test.go
+++ b/fs/diff_test.go
@@ -44,17 +44,17 @@ func skipDiffTestOnWindows(t *testing.T) {
 func TestSimpleDiff(t *testing.T) {
 	skipDiffTestOnWindows(t)
 	l1 := fstest.Apply(
-		fstest.CreateDir("/etc", 0755),
-		fstest.CreateFile("/etc/hosts", []byte("mydomain 10.0.0.1"), 0644),
-		fstest.CreateFile("/etc/profile", []byte("PATH=/usr/bin"), 0644),
-		fstest.CreateFile("/etc/unchanged", []byte("PATH=/usr/bin"), 0644),
-		fstest.CreateFile("/etc/unexpected", []byte("#!/bin/sh"), 0644),
+		fstest.CreateDir("/etc", 0o755),
+		fstest.CreateFile("/etc/hosts", []byte("mydomain 10.0.0.1"), 0o644),
+		fstest.CreateFile("/etc/profile", []byte("PATH=/usr/bin"), 0o644),
+		fstest.CreateFile("/etc/unchanged", []byte("PATH=/usr/bin"), 0o644),
+		fstest.CreateFile("/etc/unexpected", []byte("#!/bin/sh"), 0o644),
 	)
 	l2 := fstest.Apply(
-		fstest.CreateFile("/etc/hosts", []byte("mydomain 10.0.0.120"), 0644),
-		fstest.CreateFile("/etc/profile", []byte("PATH=/usr/bin"), 0666),
-		fstest.CreateDir("/root", 0700),
-		fstest.CreateFile("/root/.bashrc", []byte("PATH=/usr/sbin:/usr/bin"), 0644),
+		fstest.CreateFile("/etc/hosts", []byte("mydomain 10.0.0.120"), 0o644),
+		fstest.CreateFile("/etc/profile", []byte("PATH=/usr/bin"), 0o666),
+		fstest.CreateDir("/root", 0o700),
+		fstest.CreateFile("/root/.bashrc", []byte("PATH=/usr/sbin:/usr/bin"), 0o644),
 		fstest.Remove("/etc/unexpected"),
 	)
 	diff := []TestChange{
@@ -74,8 +74,8 @@ func TestEmptyFileDiff(t *testing.T) {
 	skipDiffTestOnWindows(t)
 	tt := time.Now().Truncate(time.Second)
 	l1 := fstest.Apply(
-		fstest.CreateDir("/etc", 0755),
-		fstest.CreateFile("/etc/empty", []byte(""), 0644),
+		fstest.CreateDir("/etc", 0o755),
+		fstest.CreateFile("/etc/empty", []byte(""), 0o644),
 		fstest.Chtimes("/etc/empty", tt, tt),
 	)
 	l2 := fstest.Apply()
@@ -89,10 +89,10 @@ func TestEmptyFileDiff(t *testing.T) {
 func TestNestedDeletion(t *testing.T) {
 	skipDiffTestOnWindows(t)
 	l1 := fstest.Apply(
-		fstest.CreateDir("/d0", 0755),
-		fstest.CreateDir("/d1", 0755),
-		fstest.CreateDir("/d1/d2", 0755),
-		fstest.CreateFile("/d1/d2/f1", []byte("mydomain 10.0.0.1"), 0644),
+		fstest.CreateDir("/d0", 0o755),
+		fstest.CreateDir("/d1", 0o755),
+		fstest.CreateDir("/d1/d2", 0o755),
+		fstest.CreateFile("/d1/d2/f1", []byte("mydomain 10.0.0.1"), 0o644),
 	)
 	l2 := fstest.Apply(
 		fstest.RemoveAll("/d0"),
@@ -111,15 +111,15 @@ func TestNestedDeletion(t *testing.T) {
 func TestDirectoryReplace(t *testing.T) {
 	skipDiffTestOnWindows(t)
 	l1 := fstest.Apply(
-		fstest.CreateDir("/dir1", 0755),
-		fstest.CreateFile("/dir1/f1", []byte("#####"), 0644),
-		fstest.CreateDir("/dir1/f2", 0755),
-		fstest.CreateFile("/dir1/f2/f3", []byte("#!/bin/sh"), 0644),
+		fstest.CreateDir("/dir1", 0o755),
+		fstest.CreateFile("/dir1/f1", []byte("#####"), 0o644),
+		fstest.CreateDir("/dir1/f2", 0o755),
+		fstest.CreateFile("/dir1/f2/f3", []byte("#!/bin/sh"), 0o644),
 	)
 	l2 := fstest.Apply(
-		fstest.CreateFile("/dir1/f11", []byte("#New file here"), 0644),
+		fstest.CreateFile("/dir1/f11", []byte("#New file here"), 0o644),
 		fstest.RemoveAll("/dir1/f2"),
-		fstest.CreateFile("/dir1/f2", []byte("Now file"), 0666),
+		fstest.CreateFile("/dir1/f2", []byte("Now file"), 0o666),
 	)
 	diff := []TestChange{
 		Add("/dir1/f11"),
@@ -133,9 +133,9 @@ func TestDirectoryReplace(t *testing.T) {
 
 func TestRemoveDirectoryTree(t *testing.T) {
 	l1 := fstest.Apply(
-		fstest.CreateDir("/dir1/dir2/dir3", 0755),
-		fstest.CreateFile("/dir1/f1", []byte("f1"), 0644),
-		fstest.CreateFile("/dir1/dir2/f2", []byte("f2"), 0644),
+		fstest.CreateDir("/dir1/dir2/dir3", 0o755),
+		fstest.CreateFile("/dir1/f1", []byte("f1"), 0o644),
+		fstest.CreateFile("/dir1/dir2/f2", []byte("f2"), 0o644),
 	)
 	l2 := fstest.Apply(
 		fstest.RemoveAll("/dir1"),
@@ -151,11 +151,11 @@ func TestRemoveDirectoryTree(t *testing.T) {
 
 func TestRemoveDirectoryTreeWithDash(t *testing.T) {
 	l1 := fstest.Apply(
-		fstest.CreateDir("/dir1/dir2/dir3", 0755),
-		fstest.CreateFile("/dir1/f1", []byte("f1"), 0644),
-		fstest.CreateFile("/dir1/dir2/f2", []byte("f2"), 0644),
-		fstest.CreateDir("/dir1-before", 0755),
-		fstest.CreateFile("/dir1-before/f2", []byte("f2"), 0644),
+		fstest.CreateDir("/dir1/dir2/dir3", 0o755),
+		fstest.CreateFile("/dir1/f1", []byte("f1"), 0o644),
+		fstest.CreateFile("/dir1/dir2/f2", []byte("f2"), 0o644),
+		fstest.CreateDir("/dir1-before", 0o755),
+		fstest.CreateFile("/dir1-before/f2", []byte("f2"), 0o644),
 	)
 	l2 := fstest.Apply(
 		fstest.RemoveAll("/dir1"),
@@ -171,12 +171,12 @@ func TestRemoveDirectoryTreeWithDash(t *testing.T) {
 
 func TestFileReplace(t *testing.T) {
 	l1 := fstest.Apply(
-		fstest.CreateFile("/dir1", []byte("a file, not a directory"), 0644),
+		fstest.CreateFile("/dir1", []byte("a file, not a directory"), 0o644),
 	)
 	l2 := fstest.Apply(
 		fstest.Remove("/dir1"),
-		fstest.CreateDir("/dir1/dir2", 0755),
-		fstest.CreateFile("/dir1/dir2/f1", []byte("also a file"), 0644),
+		fstest.CreateDir("/dir1/dir2", 0o755),
+		fstest.CreateFile("/dir1/dir2/f1", []byte("also a file"), 0o644),
 	)
 	diff := []TestChange{
 		Modify("/dir1"),
@@ -192,16 +192,16 @@ func TestFileReplace(t *testing.T) {
 func TestParentDirectoryPermission(t *testing.T) {
 	skipDiffTestOnWindows(t)
 	l1 := fstest.Apply(
-		fstest.CreateDir("/dir1", 0700),
-		fstest.CreateDir("/dir2", 0751),
-		fstest.CreateDir("/dir3", 0777),
+		fstest.CreateDir("/dir1", 0o700),
+		fstest.CreateDir("/dir2", 0o751),
+		fstest.CreateDir("/dir3", 0o777),
 	)
 	l2 := fstest.Apply(
-		fstest.CreateDir("/dir1/d", 0700),
-		fstest.CreateFile("/dir1/d/f", []byte("irrelevant"), 0644),
-		fstest.CreateFile("/dir1/f", []byte("irrelevant"), 0644),
-		fstest.CreateFile("/dir2/f", []byte("irrelevant"), 0644),
-		fstest.CreateFile("/dir3/f", []byte("irrelevant"), 0644),
+		fstest.CreateDir("/dir1/d", 0o700),
+		fstest.CreateFile("/dir1/d/f", []byte("irrelevant"), 0o644),
+		fstest.CreateFile("/dir1/f", []byte("irrelevant"), 0o644),
+		fstest.CreateFile("/dir2/f", []byte("irrelevant"), 0o644),
+		fstest.CreateFile("/dir3/f", []byte("irrelevant"), 0o644),
 	)
 	diff := []TestChange{
 		Add("/dir1/d"),
@@ -222,31 +222,31 @@ func TestUpdateWithSameTime(t *testing.T) {
 	t1 := tt.Add(5 * time.Nanosecond)
 	t2 := tt.Add(6 * time.Nanosecond)
 	l1 := fstest.Apply(
-		fstest.CreateFile("/file-modified-time", []byte("1"), 0644),
+		fstest.CreateFile("/file-modified-time", []byte("1"), 0o644),
 		fstest.Chtimes("/file-modified-time", t1, t1),
-		fstest.CreateFile("/file-no-change", []byte("1"), 0644),
+		fstest.CreateFile("/file-no-change", []byte("1"), 0o644),
 		fstest.Chtimes("/file-no-change", t1, t1),
-		fstest.CreateFile("/file-same-time", []byte("1"), 0644),
+		fstest.CreateFile("/file-same-time", []byte("1"), 0o644),
 		fstest.Chtimes("/file-same-time", t1, t1),
-		fstest.CreateFile("/file-truncated-time-1", []byte("1"), 0644),
+		fstest.CreateFile("/file-truncated-time-1", []byte("1"), 0o644),
 		fstest.Chtimes("/file-truncated-time-1", tt, tt),
-		fstest.CreateFile("/file-truncated-time-2", []byte("1"), 0644),
+		fstest.CreateFile("/file-truncated-time-2", []byte("1"), 0o644),
 		fstest.Chtimes("/file-truncated-time-2", tt, tt),
-		fstest.CreateFile("/file-truncated-time-3", []byte("1"), 0644),
+		fstest.CreateFile("/file-truncated-time-3", []byte("1"), 0o644),
 		fstest.Chtimes("/file-truncated-time-3", t1, t1),
 	)
 	l2 := fstest.Apply(
-		fstest.CreateFile("/file-modified-time", []byte("2"), 0644),
+		fstest.CreateFile("/file-modified-time", []byte("2"), 0o644),
 		fstest.Chtimes("/file-modified-time", t2, t2),
-		fstest.CreateFile("/file-no-change", []byte("1"), 0644),
+		fstest.CreateFile("/file-no-change", []byte("1"), 0o644),
 		fstest.Chtimes("/file-no-change", t1, t1),
-		fstest.CreateFile("/file-same-time", []byte("2"), 0644),
+		fstest.CreateFile("/file-same-time", []byte("2"), 0o644),
 		fstest.Chtimes("/file-same-time", t1, t1),
-		fstest.CreateFile("/file-truncated-time-1", []byte("1"), 0644),
+		fstest.CreateFile("/file-truncated-time-1", []byte("1"), 0o644),
 		fstest.Chtimes("/file-truncated-time-1", t1, t1),
-		fstest.CreateFile("/file-truncated-time-2", []byte("2"), 0644),
+		fstest.CreateFile("/file-truncated-time-2", []byte("2"), 0o644),
 		fstest.Chtimes("/file-truncated-time-2", tt, tt),
-		fstest.CreateFile("/file-truncated-time-3", []byte("1"), 0644),
+		fstest.CreateFile("/file-truncated-time-3", []byte("1"), 0o644),
 		fstest.Chtimes("/file-truncated-time-3", tt, tt),
 	)
 	diff := []TestChange{
@@ -276,7 +276,7 @@ func TestLchtimes(t *testing.T) {
 	for _, mtime := range mtimes {
 		atime := time.Unix(424242, 42)
 		l1 := fstest.Apply(
-			fstest.CreateFile("/foo", []byte("foo"), 0644),
+			fstest.CreateFile("/foo", []byte("foo"), 0o644),
 			fstest.Symlink("/foo", "/lnk0"),
 			fstest.Lchtimes("/lnk0", atime, mtime),
 		)
@@ -314,11 +314,11 @@ func testDiffWithBase(t testing.TB, base, diff fstest.Applier, expected []TestCh
 
 func TestBaseDirectoryChanges(t *testing.T) {
 	apply := fstest.Apply(
-		fstest.CreateDir("/etc", 0755),
-		fstest.CreateFile("/etc/hosts", []byte("mydomain 10.0.0.1"), 0644),
-		fstest.CreateFile("/etc/profile", []byte("PATH=/usr/bin"), 0644),
-		fstest.CreateDir("/root", 0700),
-		fstest.CreateFile("/root/.bashrc", []byte("PATH=/usr/sbin:/usr/bin"), 0644),
+		fstest.CreateDir("/etc", 0o755),
+		fstest.CreateFile("/etc/hosts", []byte("mydomain 10.0.0.1"), 0o644),
+		fstest.CreateFile("/etc/profile", []byte("PATH=/usr/bin"), 0o644),
+		fstest.CreateDir("/root", 0o700),
+		fstest.CreateFile("/root/.bashrc", []byte("PATH=/usr/sbin:/usr/bin"), 0o644),
 	)
 	changes := []TestChange{
 		Add("/etc"),
@@ -410,7 +410,6 @@ func collectChanges(a, b string) ([]TestChange, error) {
 
 func diffString(c1, c2 []TestChange) string {
 	return fmt.Sprintf("got(%d):\n%s\nexpected(%d):\n%s", len(c1), changesString(c1), len(c2), changesString(c2))
-
 }
 
 func changesString(c []TestChange) string {

--- a/fs/dtype_test.go
+++ b/fs/dtype_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestRequiresRootNOP(t *testing.T) {
-
 	// This is a dummy test case that exist to call
 	// testutil.RequiresRoot() on non-linux platforms.  This is
 	// needed because the Makfile root-coverage tests target

--- a/fs/du_test.go
+++ b/fs/du_test.go
@@ -46,27 +46,27 @@ func TestUsage(t *testing.T) {
 		{
 			name: "SingleSmallFile",
 			fs: fstest.Apply(
-				fstest.CreateDir("/dir", 0755),
-				fstest.CreateRandomFile("/dir/file", 1, 5, 0644),
+				fstest.CreateDir("/dir", 0o755),
+				fstest.CreateRandomFile("/dir/file", 1, 5, 0o644),
 			),
 			size: dirs(2) + align(5),
 		},
 		{
 			name: "MultipleSmallFile",
 			fs: fstest.Apply(
-				fstest.CreateDir("/dir", 0755),
-				fstest.CreateRandomFile("/dir/file1", 2, 5, 0644),
-				fstest.CreateRandomFile("/dir/file2", 3, 5, 0644),
+				fstest.CreateDir("/dir", 0o755),
+				fstest.CreateRandomFile("/dir/file1", 2, 5, 0o644),
+				fstest.CreateRandomFile("/dir/file2", 3, 5, 0o644),
 			),
 			size: dirs(2) + align(5)*2,
 		},
 		{
 			name: "BiggerFiles",
 			fs: fstest.Apply(
-				fstest.CreateDir("/dir", 0755),
-				fstest.CreateRandomFile("/dir/file1", 4, 5, 0644),
-				fstest.CreateRandomFile("/dir/file2", 5, 1024, 0644),
-				fstest.CreateRandomFile("/dir/file3", 6, 50*1024, 0644),
+				fstest.CreateDir("/dir", 0o755),
+				fstest.CreateRandomFile("/dir/file1", 4, 5, 0o644),
+				fstest.CreateRandomFile("/dir/file2", 5, 1024, 0o644),
+				fstest.CreateRandomFile("/dir/file3", 6, 50*1024, 0o644),
 			),
 			size: dirs(2) + align(5) + align(1024) + align(50*1024),
 		},
@@ -76,19 +76,19 @@ func TestUsage(t *testing.T) {
 			{
 				name: "SparseFiles",
 				fs: fstest.Apply(
-					fstest.CreateDir("/dir", 0755),
-					fstest.CreateRandomFile("/dir/file1", 7, 5, 0644),
-					createSparseFile("/dir/sparse1", 8, 0644, 5, 1024*1024, 5),
-					createSparseFile("/dir/sparse2", 9, 0644, 0, 1024*1024),
-					createSparseFile("/dir/sparse2", 10, 0644, 0, 1024*1024*1024, 1024),
+					fstest.CreateDir("/dir", 0o755),
+					fstest.CreateRandomFile("/dir/file1", 7, 5, 0o644),
+					createSparseFile("/dir/sparse1", 8, 0o644, 5, 1024*1024, 5),
+					createSparseFile("/dir/sparse2", 9, 0o644, 0, 1024*1024),
+					createSparseFile("/dir/sparse2", 10, 0o644, 0, 1024*1024*1024, 1024),
 				),
 				size: dirs(2) + align(5)*3 + align(1024),
 			},
 			{
 				name: "Hardlinks",
 				fs: fstest.Apply(
-					fstest.CreateDir("/dir", 0755),
-					fstest.CreateRandomFile("/dir/file1", 11, 60*1024, 0644),
+					fstest.CreateDir("/dir", 0o755),
+					fstest.CreateRandomFile("/dir/file1", 11, 60*1024, 0o644),
 					fstest.Link("/dir/file1", "/dir/link1"),
 				),
 				size: dirs(2) + align(60*1024),
@@ -96,8 +96,8 @@ func TestUsage(t *testing.T) {
 			{
 				name: "HardlinkSparefile",
 				fs: fstest.Apply(
-					fstest.CreateDir("/dir", 0755),
-					createSparseFile("/dir/file1", 10, 0644, 30*1024, 1024*1024*1024, 30*1024),
+					fstest.CreateDir("/dir", 0o755),
+					createSparseFile("/dir/file1", 10, 0o644, 30*1024, 1024*1024*1024, 30*1024),
 					fstest.Link("/dir/file1", "/dir/link1"),
 				),
 				size: dirs(2) + align(30*1024)*2,

--- a/fs/du_unix.go
+++ b/fs/du_unix.go
@@ -28,10 +28,11 @@ import (
 
 // blocksUnitSize is the unit used by `st_blocks` in `stat` in bytes.
 // See https://man7.org/linux/man-pages/man2/stat.2.html
-//   st_blocks
-//     This field indicates the number of blocks allocated to the
-//     file, in 512-byte units.  (This may be smaller than
-//     st_size/512 when the file has holes.)
+//
+//	st_blocks
+//	  This field indicates the number of blocks allocated to the
+//	  file, in 512-byte units.  (This may be smaller than
+//	  st_size/512 when the file has holes.)
 const blocksUnitSize = 512
 
 type inode struct {
@@ -48,7 +49,6 @@ func newInode(stat *syscall.Stat_t) inode {
 }
 
 func diskUsage(ctx context.Context, roots ...string) (Usage, error) {
-
 	var (
 		size   int64
 		inodes = map[inode]struct{}{} // expensive!

--- a/fs/du_windows.go
+++ b/fs/du_windows.go
@@ -26,9 +26,7 @@ import (
 )
 
 func diskUsage(ctx context.Context, roots ...string) (Usage, error) {
-	var (
-		size int64
-	)
+	var size int64
 
 	// TODO(stevvooe): Support inodes (or equivalent) for windows.
 
@@ -57,9 +55,7 @@ func diskUsage(ctx context.Context, roots ...string) (Usage, error) {
 }
 
 func diffUsage(ctx context.Context, a, b string) (Usage, error) {
-	var (
-		size int64
-	)
+	var size int64
 
 	if err := Changes(ctx, a, b, func(kind ChangeKind, _ string, fi os.FileInfo, err error) error {
 		if err != nil {

--- a/fs/fstest/continuity_util.go
+++ b/fs/fstest/continuity_util.go
@@ -129,7 +129,6 @@ func compareResource(r1, r2 continuity.Resource) bool {
 	// TODO(dmcgowan): Check if is XAttrer
 
 	return compareResourceTypes(r1, r2)
-
 }
 
 func compareResourceTypes(r1, r2 continuity.Resource) bool {

--- a/fs/fstest/file_windows.go
+++ b/fs/fstest/file_windows.go
@@ -32,13 +32,13 @@ func Lchtimes(name string, atime, mtime time.Time) Applier {
 // that the filter will mount. It is used for testing the snapshotter
 func Base() Applier {
 	return Apply(
-		CreateDir("Windows", 0755),
-		CreateDir("Windows/System32", 0755),
-		CreateDir("Windows/System32/Config", 0755),
-		CreateFile("Windows/System32/Config/SYSTEM", []byte("foo\n"), 0777),
-		CreateFile("Windows/System32/Config/SOFTWARE", []byte("foo\n"), 0777),
-		CreateFile("Windows/System32/Config/SAM", []byte("foo\n"), 0777),
-		CreateFile("Windows/System32/Config/SECURITY", []byte("foo\n"), 0777),
-		CreateFile("Windows/System32/Config/DEFAULT", []byte("foo\n"), 0777),
+		CreateDir("Windows", 0o755),
+		CreateDir("Windows/System32", 0o755),
+		CreateDir("Windows/System32/Config", 0o755),
+		CreateFile("Windows/System32/Config/SYSTEM", []byte("foo\n"), 0o777),
+		CreateFile("Windows/System32/Config/SOFTWARE", []byte("foo\n"), 0o777),
+		CreateFile("Windows/System32/Config/SAM", []byte("foo\n"), 0o777),
+		CreateFile("Windows/System32/Config/SECURITY", []byte("foo\n"), 0o777),
+		CreateFile("Windows/System32/Config/DEFAULT", []byte("foo\n"), 0o777),
 	)
 }

--- a/fs/fstest/testsuite.go
+++ b/fs/fstest/testsuite.go
@@ -81,14 +81,14 @@ var (
 	// baseApplier creates a basic filesystem layout
 	// with multiple types of files for basic tests.
 	baseApplier = Apply(
-		CreateDir("/etc/", 0755),
-		CreateFile("/etc/hosts", []byte("127.0.0.1 localhost"), 0644),
+		CreateDir("/etc/", 0o755),
+		CreateFile("/etc/hosts", []byte("127.0.0.1 localhost"), 0o644),
 		Link("/etc/hosts", "/etc/hosts.allow"),
-		CreateDir("/usr/local/lib", 0755),
-		CreateFile("/usr/local/lib/libnothing.so", []byte{0x00, 0x00}, 0755),
+		CreateDir("/usr/local/lib", 0o755),
+		CreateFile("/usr/local/lib/libnothing.so", []byte{0x00, 0x00}, 0o755),
 		Symlink("libnothing.so", "/usr/local/lib/libnothing.so.2"),
-		CreateDir("/home", 0755),
-		CreateDir("/home/derek", 0700),
+		CreateDir("/home", 0o755),
+		CreateDir("/home/derek", 0o700),
 		// TODO: CreateSocket: how should Sockets be handled in continuity?
 	)
 
@@ -96,10 +96,10 @@ var (
 	basicTest = []Applier{
 		baseApplier,
 		Apply(
-			CreateFile("/etc/hosts", []byte("127.0.0.1 localhost.localdomain"), 0644),
-			CreateFile("/etc/fstab", []byte("/dev/sda1\t/\text4\tdefaults 1 1\n"), 0600),
-			CreateFile("/etc/badfile", []byte(""), 0666),
-			CreateFile("/home/derek/.zshrc", []byte("#ZSH is just better\n"), 0640),
+			CreateFile("/etc/hosts", []byte("127.0.0.1 localhost.localdomain"), 0o644),
+			CreateFile("/etc/fstab", []byte("/dev/sda1\t/\text4\tdefaults 1 1\n"), 0o600),
+			CreateFile("/etc/badfile", []byte(""), 0o666),
+			CreateFile("/home/derek/.zshrc", []byte("#ZSH is just better\n"), 0o640),
 		),
 		Apply(
 			Remove("/etc/badfile"),
@@ -111,8 +111,8 @@ var (
 		),
 		Apply(
 			RemoveAll("/home"),
-			CreateDir("/home/derek", 0700),
-			CreateFile("/home/derek/.bashrc", []byte("#not going away\n"), 0640),
+			CreateDir("/home/derek", 0o700),
+			CreateFile("/home/derek/.bashrc", []byte("#not going away\n"), 0o640),
 			Link("/etc/hosts", "/etc/hosts.allow"),
 		),
 	}
@@ -121,58 +121,58 @@ var (
 	// deletions are properly picked up and applied
 	deletionTest = []Applier{
 		Apply(
-			CreateDir("/test/somedir", 0755),
-			CreateDir("/lib", 0700),
-			CreateFile("/lib/hidden", []byte{}, 0644),
+			CreateDir("/test/somedir", 0o755),
+			CreateDir("/lib", 0o700),
+			CreateFile("/lib/hidden", []byte{}, 0o644),
 		),
 		Apply(
-			CreateFile("/test/a", []byte{}, 0644),
-			CreateFile("/test/b", []byte{}, 0644),
-			CreateDir("/test/otherdir", 0755),
-			CreateFile("/test/otherdir/.empty", []byte{}, 0644),
+			CreateFile("/test/a", []byte{}, 0o644),
+			CreateFile("/test/b", []byte{}, 0o644),
+			CreateDir("/test/otherdir", 0o755),
+			CreateFile("/test/otherdir/.empty", []byte{}, 0o644),
 			RemoveAll("/lib"),
-			CreateDir("/lib", 0700),
-			CreateFile("/lib/not-hidden", []byte{}, 0644),
+			CreateDir("/lib", 0o700),
+			CreateFile("/lib/not-hidden", []byte{}, 0o644),
 		),
 		Apply(
 			Remove("/test/a"),
 			Remove("/test/b"),
 			RemoveAll("/test/otherdir"),
-			CreateFile("/lib/newfile", []byte{}, 0644),
+			CreateFile("/lib/newfile", []byte{}, 0o644),
 		),
 	}
 
 	// updateTest covers file updates for content and permission
 	updateTest = []Applier{
 		Apply(
-			CreateDir("/d1", 0755),
-			CreateDir("/d2", 0700),
-			CreateFile("/d1/f1", []byte("something..."), 0644),
-			CreateFile("/d1/f2", []byte("else..."), 0644),
-			CreateFile("/d1/f3", []byte("entirely..."), 0644),
+			CreateDir("/d1", 0o755),
+			CreateDir("/d2", 0o700),
+			CreateFile("/d1/f1", []byte("something..."), 0o644),
+			CreateFile("/d1/f2", []byte("else..."), 0o644),
+			CreateFile("/d1/f3", []byte("entirely..."), 0o644),
 		),
 		Apply(
-			CreateFile("/d1/f1", []byte("file content of a different length"), 0664),
+			CreateFile("/d1/f1", []byte("file content of a different length"), 0o664),
 			Remove("/d1/f3"),
-			CreateFile("/d1/f3", []byte("updated content"), 0664),
-			Chmod("/d1/f2", 0766),
-			Chmod("/d2", 0777),
+			CreateFile("/d1/f3", []byte("updated content"), 0o664),
+			Chmod("/d1/f2", 0o766),
+			Chmod("/d2", 0o777),
 		),
 	}
 
 	// directoryPermissionsTest covers directory permissions on update
 	directoryPermissionsTest = []Applier{
 		Apply(
-			CreateDir("/d1", 0700),
-			CreateDir("/d2", 0751),
-			CreateDir("/d3", 0777),
+			CreateDir("/d1", 0o700),
+			CreateDir("/d2", 0o751),
+			CreateDir("/d3", 0o777),
 		),
 		Apply(
-			CreateFile("/d1/f", []byte("irrelevant"), 0644),
-			CreateDir("/d1/d", 0700),
-			CreateFile("/d1/d/f", []byte("irrelevant"), 0644),
-			CreateFile("/d2/f", []byte("irrelevant"), 0644),
-			CreateFile("/d3/f", []byte("irrelevant"), 0644),
+			CreateFile("/d1/f", []byte("irrelevant"), 0o644),
+			CreateDir("/d1/d", 0o700),
+			CreateFile("/d1/d/f", []byte("irrelevant"), 0o644),
+			CreateFile("/d2/f", []byte("irrelevant"), 0o644),
+			CreateFile("/d3/f", []byte("irrelevant"), 0o644),
 		),
 	}
 
@@ -180,28 +180,28 @@ var (
 	// files
 	parentDirectoryPermissionsTest = []Applier{
 		Apply(
-			CreateDir("/d1", 0700),
-			CreateDir("/d1/a", 0700),
-			CreateDir("/d1/a/b", 0700),
-			CreateDir("/d1/a/b/c", 0700),
-			CreateFile("/d1/a/b/f", []byte("content1"), 0644),
-			CreateDir("/d2", 0751),
-			CreateDir("/d2/a/b", 0751),
-			CreateDir("/d2/a/b/c", 0751),
-			CreateFile("/d2/a/b/f", []byte("content1"), 0644),
+			CreateDir("/d1", 0o700),
+			CreateDir("/d1/a", 0o700),
+			CreateDir("/d1/a/b", 0o700),
+			CreateDir("/d1/a/b/c", 0o700),
+			CreateFile("/d1/a/b/f", []byte("content1"), 0o644),
+			CreateDir("/d2", 0o751),
+			CreateDir("/d2/a/b", 0o751),
+			CreateDir("/d2/a/b/c", 0o751),
+			CreateFile("/d2/a/b/f", []byte("content1"), 0o644),
 		),
 		Apply(
-			CreateFile("/d1/a/b/f", []byte("content1"), 0644),
-			Chmod("/d1/a/b/c", 0700),
-			CreateFile("/d2/a/b/f", []byte("content2"), 0644),
-			Chmod("/d2/a/b/c", 0751),
+			CreateFile("/d1/a/b/f", []byte("content1"), 0o644),
+			Chmod("/d1/a/b/c", 0o700),
+			CreateFile("/d2/a/b/f", []byte("content2"), 0o644),
+			Chmod("/d2/a/b/c", 0o751),
 		),
 	}
 
 	hardlinkUnmodified = []Applier{
 		baseApplier,
 		Apply(
-			CreateFile("/etc/hosts", []byte("127.0.0.1 localhost.localdomain"), 0644),
+			CreateFile("/etc/hosts", []byte("127.0.0.1 localhost.localdomain"), 0o644),
 		),
 		Apply(
 			Link("/etc/hosts", "/etc/hosts.deny"),
@@ -213,7 +213,7 @@ var (
 	hardlinkBeforeUnmodified = []Applier{
 		baseApplier,
 		Apply(
-			CreateFile("/etc/hosts", []byte("127.0.0.1 localhost.localdomain"), 0644),
+			CreateFile("/etc/hosts", []byte("127.0.0.1 localhost.localdomain"), 0o644),
 		),
 		Apply(
 			Link("/etc/hosts", "/etc/before-hosts"),
@@ -225,11 +225,11 @@ var (
 	hardlinkBeforeModified = []Applier{
 		baseApplier,
 		Apply(
-			CreateFile("/etc/hosts", []byte("127.0.0.1 localhost.localdomain"), 0644),
+			CreateFile("/etc/hosts", []byte("127.0.0.1 localhost.localdomain"), 0o644),
 		),
 		Apply(
 			Remove("/etc/hosts"),
-			CreateFile("/etc/hosts", []byte("127.0.0.1 localhost"), 0644),
+			CreateFile("/etc/hosts", []byte("127.0.0.1 localhost"), 0o644),
 			Link("/etc/hosts", "/etc/before-hosts"),
 		),
 	}

--- a/fs/path.go
+++ b/fs/path.go
@@ -25,9 +25,7 @@ import (
 	"path/filepath"
 )
 
-var (
-	errTooManyLinks = errors.New("too many links")
-)
+var errTooManyLinks = errors.New("too many links")
 
 type currentPath struct {
 	path     string

--- a/fs/path_test.go
+++ b/fs/path_test.go
@@ -131,7 +131,7 @@ func TestRootPath(t *testing.T) {
 				Symlink("foo", "bar"),
 				Symlink("bar", "foo"),
 			),
-			checks: ErrorWithScope("foo", "", errTooManyLinks), //TODO: Test for circular error
+			checks: ErrorWithScope("foo", "", errTooManyLinks), // TODO: Test for circular error
 		},
 		{
 			name: "SymlinkCircularUnderRoot",
@@ -145,7 +145,7 @@ func TestRootPath(t *testing.T) {
 		{
 			name: "SymlinkComplexChain",
 			apply: fstest.Apply(
-				fstest.CreateDir("root2", 0777),
+				fstest.CreateDir("root2", 0o777),
 				Symlink("root2", "root"),
 				Symlink("r/s", "root/a"),
 				Symlink("../root/t", "root/r"),
@@ -338,7 +338,7 @@ func Symlink(oldname, newname string) fstest.Applier {
 	dir := filepath.Dir(newname)
 	if dir != "" {
 		return fstest.Apply(
-			fstest.CreateDir(dir, 0755),
+			fstest.CreateDir(dir, 0o755),
 			fstest.Symlink(oldname, newname),
 		)
 	}

--- a/hardlinks.go
+++ b/hardlinks.go
@@ -21,9 +21,7 @@ import (
 	"os"
 )
 
-var (
-	errNotAHardLink = fmt.Errorf("invalid hardlink")
-)
+var errNotAHardLink = fmt.Errorf("invalid hardlink")
 
 type hardlinkManager struct {
 	hardlinks map[hardlinkKey][]Resource

--- a/ioutils_test.go
+++ b/ioutils_test.go
@@ -27,7 +27,7 @@ func TestAtomicWriteFile(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	expected := []byte("barbaz")
-	if err := AtomicWriteFile(filepath.Join(tmpDir, "foo"), expected, 0666); err != nil {
+	if err := AtomicWriteFile(filepath.Join(tmpDir, "foo"), expected, 0o666); err != nil {
 		t.Fatalf("Error writing to file: %v", err)
 	}
 
@@ -44,7 +44,7 @@ func TestAtomicWriteFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error statting file: %v", err)
 	}
-	if expected := os.FileMode(0666); st.Mode() != expected {
+	if expected := os.FileMode(0o666); st.Mode() != expected {
 		t.Fatalf("Mode mismatched, expected %o, got %o", expected, st.Mode())
 	}
 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -61,7 +61,7 @@ func TestWalkFS(t *testing.T) {
 	testResources := []dresource{
 		{
 			path: "a",
-			mode: 0644,
+			mode: 0o644,
 		},
 		{
 			kind:   rhardlink,
@@ -71,7 +71,7 @@ func TestWalkFS(t *testing.T) {
 		{
 			kind: rdirectory,
 			path: "b",
-			mode: 0755,
+			mode: 0o755,
 		},
 		{
 			kind:   rhardlink,
@@ -80,33 +80,33 @@ func TestWalkFS(t *testing.T) {
 		},
 		{
 			path: "b/a",
-			mode: 0600 | os.ModeSticky,
+			mode: 0o600 | os.ModeSticky,
 		},
 		{
 			kind: rdirectory,
 			path: "c",
-			mode: 0755,
+			mode: 0o755,
 		},
 		{
 			path: "c/a",
-			mode: 0644,
+			mode: 0o644,
 		},
 		{
 			kind:   rrelsymlink,
 			path:   "c/ca-relsymlink",
-			mode:   0600,
+			mode:   0o600,
 			target: "a",
 		},
 		{
 			kind:   rrelsymlink,
 			path:   "c/a-relsymlink",
-			mode:   0600,
+			mode:   0o600,
 			target: "../a",
 		},
 		{
 			kind:   rabssymlink,
 			path:   "c/a-abssymlink",
-			mode:   0600,
+			mode:   0o600,
 			target: "a",
 		},
 		// TODO(stevvooe): Make sure we can test this case and get proper
@@ -125,13 +125,13 @@ func TestWalkFS(t *testing.T) {
 		{
 			kind: rnamedpipe,
 			path: "fifo",
-			mode: 0666 | os.ModeNamedPipe,
+			mode: 0o666 | os.ModeNamedPipe,
 		},
 
 		{
 			kind: rdirectory,
 			path: "/dev",
-			mode: 0755,
+			mode: 0o755,
 		},
 
 		// NOTE(stevvooe): Below here, we add a few simple character devices.

--- a/manifest_test_darwin.go
+++ b/manifest_test_darwin.go
@@ -27,7 +27,7 @@ var (
 		path:  "/dev/null",
 		major: 3,
 		minor: 2,
-		mode:  0666 | os.ModeDevice | os.ModeCharDevice,
+		mode:  0o666 | os.ModeDevice | os.ModeCharDevice,
 	}
 
 	devZeroResource = resource{
@@ -35,6 +35,6 @@ var (
 		path:  "/dev/zero",
 		major: 3,
 		minor: 3,
-		mode:  0666 | os.ModeDevice | os.ModeCharDevice,
+		mode:  0o666 | os.ModeDevice | os.ModeCharDevice,
 	}
 )


### PR DESCRIPTION
gofumpt (https://github.com/mvdan/gofumpt) provides a superset of Go's gofmt. While slightly more strict, it also helps some formatting issues that linters (such as "revive") may trip over, so let's do a one-time format of the code with gofumpt.
