### PR TITLE
Add Go 1.20 support to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  GO_VERSION: 1.20.x
+
 jobs:
 
   #
@@ -25,9 +28,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: ${{ env.GO_VERSION }}
 
-      - uses: containerd/project-checks@v1
+      - uses: containerd/project-checks@v1.1.0
         with:
           working-directory: src/github.com/containerd/continuity
 
@@ -45,7 +48,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Git line endings
       shell: bash
@@ -60,7 +63,7 @@ jobs:
         fetch-depth: 25
 
     - name: Dependencies
-      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
     - name: Lint
       shell: bash
@@ -99,7 +102,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Setup Go binary path
       shell: bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/continuity
 
-go 1.17
+go 1.19
 
 require (
 	github.com/Microsoft/go-winio v0.5.2


### PR DESCRIPTION
Update Go compiler in CI to Go 1.20. Update golangci-lint to v1.51.x for
Go 1.20 support. Update minimum Go version to Go 1.19 in go.mod.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>