### PR TITLE
Update GitHub Actions runner images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-10.15, windows-2019]
+        os: [ubuntu-22.04, macos-12, windows-2019, windows-2022]
 
     steps:
     - name: Set up Go


### PR DESCRIPTION
Resolves deprecation warnings in CI by moving macOS from 10.15 to 12.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>