### PR TITLE
Support darwin clonefile

### DIFF
--- a/fs/copy.go
+++ b/fs/copy.go
@@ -184,6 +184,10 @@ func copyDirectory(dst, src string, inodes map[uint64]string, o *copyDirOpts) er
 // CopyFile copies the source file to the target.
 // The most efficient means of copying is used for the platform.
 func CopyFile(target, source string) error {
+	return copyFile(target, source)
+}
+
+func openAndCopyFile(target, source string) error {
 	src, err := os.Open(source)
 	if err != nil {
 		return fmt.Errorf("failed to open source %s: %w", source, err)

--- a/fs/copy_darwin.go
+++ b/fs/copy_darwin.go
@@ -1,0 +1,35 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func copyFile(target, source string) error {
+	if err := unix.Clonefile(source, target, unix.CLONE_NOFOLLOW); err != nil {
+		if !errors.Is(err, unix.ENOTSUP) {
+			return fmt.Errorf("clonefile failed: %w", err)
+		}
+
+		return openAndCopyFile(target, source)
+	}
+	return nil
+}

--- a/fs/copy_nondarwin.go
+++ b/fs/copy_nondarwin.go
@@ -1,0 +1,22 @@
+//go:build !darwin
+// +build !darwin
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+var copyFile = openAndCopyFile

--- a/fs/copy_test.go
+++ b/fs/copy_test.go
@@ -19,6 +19,7 @@ package fs
 import (
 	_ "crypto/sha256"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -88,4 +89,38 @@ func testCopy(t testing.TB, apply fstest.Applier) error {
 	}
 
 	return fstest.CheckDirectoryEqual(t1, t2)
+}
+
+func BenchmarkLargeCopy100MB(b *testing.B) {
+	benchmarkLargeCopyFile(b, 100*1024*1024)
+}
+
+func BenchmarkLargeCopy1GB(b *testing.B) {
+	benchmarkLargeCopyFile(b, 1024*1024*1024)
+}
+
+func benchmarkLargeCopyFile(b *testing.B, size int64) {
+	b.StopTimer()
+	base := b.TempDir()
+	apply := fstest.Apply(
+		fstest.CreateRandomFile("/large", time.Now().UnixNano(), size, 0o644),
+	)
+	if err := apply.Apply(base); err != nil {
+		b.Fatal("failed to apply changes:", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		copied := b.TempDir()
+		b.StartTimer()
+		if err := CopyDir(copied, base); err != nil {
+			b.Fatal("failed to copy:", err)
+		}
+		b.StopTimer()
+		if i == 0 {
+			if err := fstest.CheckDirectoryEqual(base, copied); err != nil {
+				b.Fatal("check failed:", err)
+			}
+		}
+		os.RemoveAll(copied)
+	}
 }


### PR DESCRIPTION
Adds clonefile support on copy for Darwin.

Added benchmark to show it is working
```
goos: darwin
goarch: amd64
pkg: github.com/containerd/continuity/fs
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
                  │   before.txt    │              after.txt              │
                  │     sec/op      │   sec/op     vs base                │
LargeCopy100MB-16    92802.9µ ± 11%   412.2µ ± 3%  -99.56% (p=0.000 n=10)
LargeCopy1GB-16     894137.8µ ± 11%   409.6µ ± 3%  -99.95% (p=0.000 n=10)
geomean                288.1m         410.9µ       -99.86%

                  │   before.txt   │              after.txt               │
                  │      B/op      │     B/op      vs base                │
LargeCopy100MB-16   38.913Ki ±  6%   3.961Ki ± 0%  -89.82% (p=0.000 n=10)
LargeCopy1GB-16     45.193Ki ± 18%   3.961Ki ± 0%  -91.24% (p=0.000 n=10)
geomean              41.94Ki         3.961Ki       -90.55%

                  │ before.txt │             after.txt              │
                  │ allocs/op  │ allocs/op   vs base                │
LargeCopy100MB-16   41.00 ± 0%   35.00 ± 0%  -14.63% (p=0.000 n=10)
LargeCopy1GB-16     42.50 ± 4%   35.00 ± 0%  -17.65% (p=0.000 n=10)
geomean             41.74        35.00       -16.15%
```