### PR TITLE
fs/fstest: CreateFile should use sync

### DIFF
--- a/fs/fstest/file.go
+++ b/fs/fstest/file.go
@@ -65,7 +65,12 @@ func writeFileStream(name string, stream func() io.Reader, perm os.FileMode) App
 			return err
 		}
 		defer func() {
-			err := f.Close()
+			err := f.Sync()
+			if err != nil && retErr == nil {
+				retErr = err
+			}
+
+			err = f.Close()
 			if err != nil && retErr == nil {
 				retErr = err
 			}


### PR DESCRIPTION
Sync ensures that the data has been flushed.