### PR TITLE
Substitute deprecated rand.Seed() in Go 1.20

### DIFF
--- a/cmd/continuity/go.mod
+++ b/cmd/continuity/go.mod
@@ -15,7 +15,7 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/sys v0.0.0-20220405210540-1e041c57c461 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
 )
 

--- a/cmd/continuity/go.sum
+++ b/cmd/continuity/go.sum
@@ -54,6 +54,8 @@ golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220405210540-1e041c57c461 h1:kHVeDEnfKn3T238CvrUcz6KeEsFHVaKh4kMTt6Wsysg=
 golang.org/x/sys v0.0.0-20220405210540-1e041c57c461/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200423201157-2723c5de0d66/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -41,7 +41,6 @@ import (
 //  3. ADS - no clue where to start.
 
 func TestWalkFS(t *testing.T) {
-	rand.Seed(1)
 
 	// Testing:
 	// 1. Setup different files:
@@ -219,6 +218,10 @@ const (
 	rnamedpipe
 )
 
+var (
+	rng = rand.New(rand.NewSource(1))
+)
+
 type dresource struct {
 	kind         kind
 	path         string
@@ -236,7 +239,7 @@ func generateTestFiles(t *testing.T, root string, resources []dresource) {
 		p := filepath.Join(root, resource.path)
 		switch resource.kind {
 		case rfile:
-			size := rand.Intn(4 << 20)
+			size := rng.Intn(4 << 20)
 			d := make([]byte, size)
 			randomBytes(d)
 			dgst := digest.FromBytes(d)
@@ -312,7 +315,7 @@ func generateTestFiles(t *testing.T, root string, resources []dresource) {
 
 func randomBytes(p []byte) {
 	for i := range p {
-		p[i] = byte(rand.Intn(1<<8 - 1))
+		p[i] = byte(rng.Intn(1<<8 - 1))
 	}
 }
 


### PR DESCRIPTION
[rand.Seed](https://pkg.go.dev/math/rand#Seed) is deprecated since Go 1.20. 

Compiling this package with Go 1.20 resulted in the following linter error:

> manifest_test.go:44:2: SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: Programs that call Seed and then expect a specific sequence of results from the global random source (using functions such as Int) can be broken when a dependency changes how much it consumes from the global random source. To avoid such breakages, programs that need a specific result sequence should use NewRand(NewSource(seed)) to obtain a random generator that other packages cannot access. (staticcheck)
	rand.Seed(1)
	^
make: *** [Makefile:48: lint] Error 1