### PR TITLE
update golangci-lint to vl.55.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         fetch-depth: 25
 
     - name: Dependencies
-      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.0
 
     - name: Lint
       shell: bash

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,5 +12,11 @@ linters:
   disable:
     - errcheck
 
+issues:
+  exclude-rules:
+    - linters:
+        - revive
+      text: "unused-parameter"
+
 run:
   timeout: 3m


### PR DESCRIPTION
Update golangci-lint to v1.55.0, matching containerd.

The update requires disabling the "unused-parameter" check, similar to [containerd](https://github.com/containerd/containerd/blob/main/.golangci.yml#L44-L46).

