### PR TITLE
Adds target for generating code coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Test coverage profiles
+codecov/


### PR DESCRIPTION
This commit adds `codecov` make target for generating codecov/report.html.