### PR TITLE
fs: properly handle ENOTSUP in copyXAttrs

### DIFF
--- a/fs/copy_linux.go
+++ b/fs/copy_linux.go
@@ -17,6 +17,7 @@
 package fs
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -64,6 +65,9 @@ func copyFileInfo(fi os.FileInfo, src, name string) error {
 func copyXAttrs(dst, src string, excludes map[string]struct{}, errorHandler XAttrErrorHandler) error {
 	xattrKeys, err := sysx.LListxattr(src)
 	if err != nil {
+		if errors.Is(err, unix.ENOTSUP) {
+			return nil
+		}
 		e := fmt.Errorf("failed to list xattrs on %s: %w", src, err)
 		if errorHandler != nil {
 			e = errorHandler(dst, src, "", e)

--- a/fs/copy_unix.go
+++ b/fs/copy_unix.go
@@ -20,12 +20,14 @@
 package fs
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
 	"syscall"
 
 	"github.com/containerd/continuity/sysx"
+	"golang.org/x/sys/unix"
 )
 
 func copyFileInfo(fi os.FileInfo, src, name string) error {
@@ -65,6 +67,9 @@ func copyXAttrs(dst, src string, excludes map[string]struct{}, errorHandler XAtt
 	if err != nil {
 		if os.IsPermission(err) && runtime.GOOS == "darwin" {
 			// On darwin, character devices do not permit listing xattrs
+			return nil
+		}
+		if errors.Is(err, unix.ENOTSUP) {
 			return nil
 		}
 		e := fmt.Errorf("failed to list xattrs on %s: %w", src, err)


### PR DESCRIPTION
Fixes #244. More context in the issue.

Filesystems without xattr support do not have any xattrs to copy. The syscall for this will return ENOTSUP to indicate this, but continuity will treat it as a regular error. This change will return nil if this call returns ENOTSUP.