### PR TITLE
Fix TestDiffDirChangeWithOverlayfs (also updates the CI to use Ubuntu 24.04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   #
   project:
     name: Project Checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2019, windows-2022]
+        os: [ubuntu-24.04, macos-12, windows-2019, windows-2022]
 
     steps:
     - name: Set up Go
@@ -87,7 +87,7 @@ jobs:
       working-directory: src/github.com/containerd/continuity
   cross:
     name: Cross-compile
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [project]
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     timeout-minutes: 30
 

--- a/fs/copy_linux_test.go
+++ b/fs/copy_linux_test.go
@@ -86,7 +86,8 @@ func TestCopyReflinkWithXFS(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("Loopback file size (after copying a %d-byte file): %d", aSize, loopbackSize)
-	allowedSize := int64(120 << 20) // 120MB
+	// 170 MiB is needed since Ubuntu 24.04. 120 MiB was enough for Ubuntu 22.04.
+	allowedSize := int64(170 << 20)
 	if loopbackSize > allowedSize {
 		t.Fatalf("expected <= %d, got %d", allowedSize, loopbackSize)
 	}

--- a/fs/fstest/mkfs_linux.go
+++ b/fs/fstest/mkfs_linux.go
@@ -1,0 +1,44 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fstest
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/containerd/continuity/testutil"
+	"github.com/containerd/continuity/testutil/loopback"
+)
+
+func WithMkfs(t *testing.T, f func(), mkfs ...string) {
+	testutil.RequiresRoot(t)
+	mnt := t.TempDir()
+	loop, err := loopback.New(100 << 20) // 100 MB
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer loop.Close()
+	if out, err := exec.Command(mkfs[0], append(mkfs[1:], loop.Device)...).CombinedOutput(); err != nil {
+		t.Fatalf("could not mkfs (%v) %s: %v (out: %q)", mkfs, loop.Device, err, string(out))
+	}
+	if out, err := exec.Command("mount", loop.Device, mnt).CombinedOutput(); err != nil {
+		t.Fatalf("could not mount %s: %v (out: %q)", loop.Device, err, string(out))
+	}
+	defer testutil.Unmount(t, mnt)
+	t.Setenv("TMPDIR", mnt)
+	f()
+}

--- a/fs/fstest/mkfs_others.go
+++ b/fs/fstest/mkfs_others.go
@@ -1,0 +1,25 @@
+//go:build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fstest
+
+import "testing"
+
+func WithMkfs(t *testing.T, f func(), mkfs ...string) {
+	t.Fatal("WithMkfs requires Linux")
+}


### PR DESCRIPTION
The test was assuming TMPDIR to be on ext4, not on tmpfs.

Fix #247