### PR TITLE
gha: update CodeQL action to v3, run on go1.22

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20.x
+          go-version: 1.22.x
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,9 +34,9 @@ jobs:
           go-version: 1.22.x
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
 
       - run: make build binaries
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
### gha: update CodeQL action to run on go1.22

follow-up to f0f6869d0dfa7a977b939b91e47fe36bf9c6bbc1 (https://github.com/containerd/continuity/pull/242), where I missed
that CodeQL also had a go version set.


### gha: update CodeQL action to v3, as v2 is deprecated

Support for CodeQL actions v2 will end on December 5th, 2024

- https://github.com/github/codeql-action/blob/main/README.md#supported-versions-of-the-codeql-action
- https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/
