### PR TITLE
go-fix: remove pre-go1.17 build-tags

### DIFF
--- a/cmd/continuity/commands/mount.go
+++ b/cmd/continuity/commands/mount.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 /*
    Copyright The containerd Authors.

--- a/cmd/continuity/commands/mount_unsupported.go
+++ b/cmd/continuity/commands/mount_unsupported.go
@@ -1,5 +1,4 @@
 //go:build windows || solaris || openbsd || netbsd || dragonfly || darwin
-// +build windows solaris openbsd netbsd dragonfly darwin
 
 /*
    Copyright The containerd Authors.

--- a/cmd/continuity/continuityfs/fuse.go
+++ b/cmd/continuity/continuityfs/fuse.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 /*
    Copyright The containerd Authors.

--- a/devices/devices_unix.go
+++ b/devices/devices_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/devices/mknod_freebsd.go
+++ b/devices/mknod_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd || dragonfly
-// +build freebsd dragonfly
 
 /*
    Copyright The containerd Authors.

--- a/devices/mknod_unix.go
+++ b/devices/mknod_unix.go
@@ -1,5 +1,4 @@
 //go:build !(freebsd || windows)
-// +build !freebsd,!windows
 
 /*
    Copyright The containerd Authors.

--- a/driver/driver_unix.go
+++ b/driver/driver_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/driver/driver_windows.go
+++ b/driver/driver_windows.go
@@ -1,5 +1,4 @@
 //go:build go1.13
-// +build go1.13
 
 /*
    Copyright The containerd Authors.

--- a/driver/lchmod_unix.go
+++ b/driver/lchmod_unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || freebsd || netbsd || openbsd || dragonfly || solaris
-// +build darwin freebsd netbsd openbsd dragonfly solaris
 
 /*
    Copyright The containerd Authors.

--- a/fs/copy_irregular_unix.go
+++ b/fs/copy_irregular_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows && !freebsd
-// +build !windows,!freebsd
 
 /*
    Copyright The containerd Authors.

--- a/fs/copy_linux_test.go
+++ b/fs/copy_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/fs/copy_nondarwin.go
+++ b/fs/copy_nondarwin.go
@@ -1,5 +1,4 @@
 //go:build !darwin
-// +build !darwin
 
 /*
    Copyright The containerd Authors.

--- a/fs/copy_unix.go
+++ b/fs/copy_unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || freebsd || openbsd || netbsd || dragonfly || solaris
-// +build darwin freebsd openbsd netbsd dragonfly solaris
 
 /*
    Copyright The containerd Authors.

--- a/fs/copy_unix_test.go
+++ b/fs/copy_unix_test.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 /*
    Copyright The containerd Authors.

--- a/fs/diff_nonlinux.go
+++ b/fs/diff_nonlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
    Copyright The containerd Authors.

--- a/fs/diff_unix.go
+++ b/fs/diff_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/fs/dtype_linux.go
+++ b/fs/dtype_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/fs/dtype_linux_test.go
+++ b/fs/dtype_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/fs/du_cmd_freebsddarwin_test.go
+++ b/fs/du_cmd_freebsddarwin_test.go
@@ -1,5 +1,4 @@
 //go:build freebsd || dragonfly || darwin
-// +build freebsd dragonfly darwin
 
 /*
    Copyright The containerd Authors.

--- a/fs/du_cmd_unix_test.go
+++ b/fs/du_cmd_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows && !freebsd && !darwin && !dragonfly
-// +build !windows,!freebsd,!darwin,!dragonfly
 
 /*
    Copyright The containerd Authors.

--- a/fs/du_unix.go
+++ b/fs/du_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/fs/du_unix_test.go
+++ b/fs/du_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/fs/du_windows.go
+++ b/fs/du_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
    Copyright The containerd Authors.

--- a/fs/fstest/compare_unix.go
+++ b/fs/fstest/compare_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/fs/fstest/file_unix.go
+++ b/fs/fstest/file_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/fs/hardlink_unix.go
+++ b/fs/hardlink_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/fs/path_test.go
+++ b/fs/path_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/fs/stat_darwinbsd.go
+++ b/fs/stat_darwinbsd.go
@@ -1,5 +1,4 @@
 //go:build darwin || freebsd || netbsd
-// +build darwin freebsd netbsd
 
 /*
    Copyright The containerd Authors.

--- a/fs/stat_unix.go
+++ b/fs/stat_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || openbsd || dragonfly || solaris
-// +build linux openbsd dragonfly solaris
 
 /*
    Copyright The containerd Authors.

--- a/fs/utimesnanoat.go
+++ b/fs/utimesnanoat.go
@@ -1,5 +1,4 @@
 //go:build !(windows || linux)
-// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.

--- a/hardlinks_unix.go
+++ b/hardlinks_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/manifest_test_darwin.go
+++ b/manifest_test_darwin.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 /*
    Copyright The containerd Authors.

--- a/resource_unix.go
+++ b/resource_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/sysx/nodata_unix.go
+++ b/sysx/nodata_unix.go
@@ -1,5 +1,4 @@
 //go:build !(linux || solaris || windows)
-// +build !linux,!solaris,!windows
 
 /*
    Copyright The containerd Authors.

--- a/sysx/xattr.go
+++ b/sysx/xattr.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 /*
    Copyright The containerd Authors.

--- a/sysx/xattr_unsupported.go
+++ b/sysx/xattr_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !darwin
-// +build !linux,!darwin
 
 /*
    Copyright The containerd Authors.

--- a/testutil/helpers_unix.go
+++ b/testutil/helpers_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/testutil/mount_other.go
+++ b/testutil/mount_other.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows
-// +build !linux,!windows
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
Result of;

    go fix -mod=readonly ./...
    cd cmd/continuity go fix -mod=readonly ./...
