### PR TITLE
cmd/continuity/commands: MountCmd: remove macOS remnants

### DIFF
--- a/cmd/continuity/commands/mount.go
+++ b/cmd/continuity/commands/mount.go
@@ -75,17 +75,8 @@ var MountCmd = &cobra.Command{
 			fuse.ReadOnly(),
 			fuse.FSName(manifestName),
 			fuse.Subtype("continuity"),
-			// OSX Only options
-			fuse.LocalVolume(),
-			fuse.VolumeName("Continuity FileSystem"),
 		)
 		if err != nil {
-			log.L.Fatal(err)
-		}
-
-		<-c.Ready
-		if err := c.MountError; err != nil {
-			c.Close()
 			log.L.Fatal(err)
 		}
 


### PR DESCRIPTION
commit 5df4731d45253217b8fe4ebf823fffda8da5a7ae removed support for fuse on macOS. macOS support was removed from this dependency in [bazil.org/fuse@60eaf8f], and these options were now a stub (see [1], [dummyOption]).

[bazil.org/fuse@60eaf8f]: https://github.com/bazil/fuse/commit/60eaf8f021ce00e5c52529cdcba1067e13c1c2c2
[1]: https://github.com/bazil/fuse/blob/fb710f7dfd05053a3bc9516dd5a7a8f84ead8aab/options.go#L70-L98
[dummyOption]: https://github.com/bazil/fuse/blob/fb710f7dfd05053a3bc9516dd5a7a8f84ead8aab/options.go#L7-L9