### PR TITLE
Makefile: make "lint" target also lint cmd/continuity module and fix linting issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ generate:
 lint:
 	@echo "+ $@"
 	@golangci-lint run
+	@(cd cmd/continuity && golangci-lint --config=../../.golangci.yml run)
 
 build:
 	@echo "+ $@"

--- a/cmd/continuity/continuityfs/fuse.go
+++ b/cmd/continuity/continuityfs/fuse.go
@@ -197,7 +197,7 @@ type direnter interface {
 func (d *Dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
 	node, ok := d.nodes[name]
 	if !ok {
-		return nil, fuse.ENOENT
+		return nil, syscall.ENOENT
 	}
 	return node, nil
 }


### PR DESCRIPTION
### cmd/continuity: fix SA1019: entry.User/entry.Group is deprecated

Add nolint-comments, and a small utility to show either the user/group
name (if present), otherwise fall back to use Uid/Gid.

Before this patch:

    cd cmd/continuity
    go install
    continuity build ./continuityfs/ > manifest.pb
    continuity ls ./manifest.pb
    -rw-r--r--      7.5 kB  /fuse.go
    -rw-r--r--      1.7 kB  /provider.go

With this patch:

    cd cmd/continuity
    go install
    continuity build ./continuityfs/ > manifest.pb
    continuity ls ./manifest.pb
    -rw-r--r--  501  20  7.5 kB  /fuse.go
    -rw-r--r--  501  20  1.7 kB  /provider.go


### cmd/continuity/continuityfs: SA1019: fuse.ENOENT is deprecated

    Error: continuityfs/fuse.go:200:15: SA1019: fuse.ENOENT is deprecated: Return a syscall.Errno directly. See ToErrno for exact rules. (staticcheck)
            return nil, fuse.ENOENT
                        ^

### Makefile: make "lint" target also lint cmd/continuity module


cmd/continuity is a separate module, and therefore was not linted.