### PR TITLE
testutil: make test.root NOP

### DIFF
--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -20,8 +20,10 @@ import (
 	"flag"
 )
 
-var rootEnabled bool
-
 func init() {
-	flag.BoolVar(&rootEnabled, "test.root", false, "enable tests that require root")
+	if flag.Lookup("test.root") == nil { // avoid conflict with containerd testutil
+		var dummy bool
+		// Register this dummy flag for compatibility with existing test scripts
+		flag.BoolVar(&dummy, "test.root", false, "(Ignored)")
+	}
 }

--- a/testutil/helpers_unix.go
+++ b/testutil/helpers_unix.go
@@ -36,10 +36,6 @@ func Unmount(t *testing.T, mountPoint string) {
 // RequiresRoot skips tests that require root, unless the test.root flag has
 // been set
 func RequiresRoot(t testing.TB) {
-	if !rootEnabled {
-		t.Skip("skipping test that requires root")
-		return
-	}
 	if os.Getuid() != 0 {
 		t.Error("This test must be run as root.")
 	}


### PR DESCRIPTION
This flag is not actually needed and can be replaced by checking `os.Geteuid() == 0`.