### PR TITLE
cmd/continuity: switch to google.golang.org/protobuf/proto

### DIFF
--- a/cmd/continuity/commands/dump.go
+++ b/cmd/continuity/commands/dump.go
@@ -17,13 +17,15 @@
 package commands
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"os"
 
 	pb "github.com/containerd/continuity/proto"
-	"github.com/golang/protobuf/proto"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
 )
 
 var DumpCmd = &cobra.Command{
@@ -51,10 +53,7 @@ var DumpCmd = &cobra.Command{
 			log.Fatalf("error unmarshaling manifest: %v", err)
 		}
 
-		// TODO(stevvooe): For now, just dump the text format. Turn this into
-		// nice text output later.
-		if err := proto.MarshalText(os.Stdout, &bm); err != nil {
-			log.Fatalf("error dumping manifest: %v", err)
-		}
+		// TODO(stevvooe): For now, just dump the text format. Turn this into nice text output later.
+		_, _ = fmt.Fprintln(os.Stdout, prototext.Format(&bm))
 	},
 }

--- a/cmd/continuity/commands/main.go
+++ b/cmd/continuity/commands/main.go
@@ -22,8 +22,8 @@ import (
 	"text/tabwriter"
 
 	pb "github.com/containerd/continuity/proto"
-	"github.com/golang/protobuf/proto"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
 )
 
 var (


### PR DESCRIPTION
- relates to https://github.com/containerd/continuity/pull/204
- relates to https://github.com/containerd/continuity/pull/255



The github.com/golang/protobuf/proto module is deprecated, and the main module already switched to google.golang.org/protobuf/proto in commit 74a016961cad4d635aeb6d4efb1bcc2268700d7a. This patch updates the cmd/continuity module to use the new module as well.

Before this patch:

```console
$ cd cmd/continuity
$ go install
$ continuity build ./continuityfs > manifest.pb
$ continuity dump ./manifest.pb
resource: <
  path: "/fuse.go"
  uid: 501
  gid: 20
  mode: 420
  size: 7464
  digest: "sha256:3d86240dcc3ea8ec7ae85d6c4e0bf0be1385b5d1e38564dcec72a69b51fcf919"
>
resource: <
  path: "/provider.go"
  uid: 501
  gid: 20
  mode: 420
  size: 1728
  digest: "sha256:8e3da0fd4a8d5e454ff027d4948d4b116ddaeb5ccdd0e10af806a2ecf2599710"
>
```

With this patch:

```console
$ cd cmd/continuity
$ go install
$ continuity build ./continuityfs > manifest.pb
$ continuity dump ./manifest.pb
resource:  {
  path:  "/fuse.go"
  uid:  501
  gid:  20
  mode:  420
  size:  7464
  digest:  "sha256:3d86240dcc3ea8ec7ae85d6c4e0bf0be1385b5d1e38564dcec72a69b51fcf919"
}
resource:  {
  path:  "/provider.go"
  uid:  501
  gid:  20
  mode:  420
  size:  1728
  digest:  "sha256:8e3da0fd4a8d5e454ff027d4948d4b116ddaeb5ccdd0e10af806a2ecf2599710"
}
```