### PR TITLE
Enable dependabot updates for GitHub Actions packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This change will enable dependabot updates for GitHub Actions packages like actions/checkout and actions/setup-go used in CI.