### PR TITLE
Bump CI runner image to macOS 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-12, windows-2019, windows-2022]
+        os: [ubuntu-24.04, macos-13, windows-2019, windows-2022]
 
     steps:
     - name: Set up Go


### PR DESCRIPTION
This change bumps the runner image in CI to macOS 13. macOS 12 runners are deprecated and will be EOL in 12/2024.

Ref: https://github.com/actions/runner-images/issues/10721