### PR TITLE
Bump golangci-lint to v1.62.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         fetch-depth: 25
 
     - name: Dependencies
-      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.0
+      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
 
     - name: Lint
       shell: bash

--- a/devices/devices_unix.go
+++ b/devices/devices_unix.go
@@ -38,14 +38,14 @@ func DeviceInfo(fi os.FileInfo) (uint64, uint64, error) {
 }
 
 // mknod provides a shortcut for syscall.Mknod
-func Mknod(p string, mode os.FileMode, maj, min int) error {
+func Mknod(p string, mode os.FileMode, major, minor int) error {
 	var (
 		m   = syscallMode(mode.Perm())
 		dev uint64
 	)
 
 	if mode&os.ModeDevice != 0 {
-		dev = unix.Mkdev(uint32(maj), uint32(min))
+		dev = unix.Mkdev(uint32(major), uint32(minor))
 
 		if mode&os.ModeCharDevice != 0 {
 			m |= unix.S_IFCHR

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -109,7 +109,7 @@ type LXAttrDriver interface {
 }
 
 type DeviceInfoDriver interface {
-	DeviceInfo(fi os.FileInfo) (maj uint64, min uint64, err error)
+	DeviceInfo(fi os.FileInfo) (major uint64, minor uint64, err error)
 }
 
 // driver is a simple default implementation that sends calls out to the "os"

--- a/driver/driver_unix.go
+++ b/driver/driver_unix.go
@@ -128,6 +128,6 @@ func (d *driver) LSetxattr(path string, attrMap map[string][]byte) error {
 	return nil
 }
 
-func (d *driver) DeviceInfo(fi os.FileInfo) (maj uint64, min uint64, err error) {
+func (d *driver) DeviceInfo(fi os.FileInfo) (major uint64, minor uint64, err error) {
 	return devices.DeviceInfo(fi)
 }

--- a/fs/diff_linux.go
+++ b/fs/diff_linux.go
@@ -51,11 +51,11 @@ func overlayFSWhiteoutConvert(diffDir, path string, f os.FileInfo, changeFn Chan
 			return false, nil
 		}
 
-		maj, min, err := devices.DeviceInfo(f)
+		major, minor, err := devices.DeviceInfo(f)
 		if err != nil {
 			return false, err
 		}
-		return (maj == 0 && min == 0), nil
+		return (major == 0 && minor == 0), nil
 	}
 
 	if f.IsDir() {

--- a/fs/fstest/file.go
+++ b/fs/fstest/file.go
@@ -111,9 +111,9 @@ func CreateDir(name string, perm os.FileMode) Applier {
 }
 
 // Rename returns a file applier which renames a file
-func Rename(old, new string) Applier {
+func Rename(oldpath, newpath string) Applier {
 	return applyFn(func(root string) error {
-		return os.Rename(filepath.Join(root, old), filepath.Join(root, new))
+		return os.Rename(filepath.Join(root, oldpath), filepath.Join(root, newpath))
 	})
 }
 

--- a/fs/fstest/file_unix.go
+++ b/fs/fstest/file_unix.go
@@ -48,10 +48,10 @@ func Lchtimes(name string, atime, mtime time.Time) Applier {
 }
 
 // CreateDeviceFile provides creates devices Applier.
-func CreateDeviceFile(name string, mode os.FileMode, maj, min int) Applier {
+func CreateDeviceFile(name string, mode os.FileMode, major, minor int) Applier {
 	return applyFn(func(root string) error {
 		fullPath := filepath.Join(root, name)
-		return devices.Mknod(fullPath, mode, maj, min)
+		return devices.Mknod(fullPath, mode, major, minor)
 	})
 }
 

--- a/fs/fstest/file_windows.go
+++ b/fs/fstest/file_windows.go
@@ -37,7 +37,7 @@ func Lchtimes(name string, atime, mtime time.Time) Applier {
 }
 
 // CreateDeviceFile provides creates devices Applier.
-func CreateDeviceFile(name string, mode os.FileMode, maj, min int) Applier {
+func CreateDeviceFile(name string, mode os.FileMode, major, minor int) Applier {
 	return applyFn(func(root string) error {
 		return errors.New("Not implemented")
 	})


### PR DESCRIPTION
This change updates golangci-lint version to v1.62.0 and resolves warnings for shadowing built-in functions like `min` and `new`.