### PR TITLE
fs: handle ENOTSUP error in compareCapabilities function

### DIFF
--- a/fs/diff_unix.go
+++ b/fs/diff_unix.go
@@ -20,11 +20,13 @@ package fs
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
 
 	"github.com/containerd/continuity/sysx"
+	"golang.org/x/sys/unix"
 )
 
 // compareSysStat returns whether the stats are equivalent,
@@ -45,11 +47,11 @@ func compareSysStat(s1, s2 interface{}) (bool, error) {
 
 func compareCapabilities(p1, p2 string) (bool, error) {
 	c1, err := sysx.LGetxattr(p1, "security.capability")
-	if err != nil && err != sysx.ENODATA {
+	if err != nil && !errors.Is(err, unix.ENOTSUP) && !errors.Is(err, sysx.ENODATA) {
 		return false, fmt.Errorf("failed to get xattr for %s: %w", p1, err)
 	}
 	c2, err := sysx.LGetxattr(p2, "security.capability")
-	if err != nil && err != sysx.ENODATA {
+	if err != nil && !errors.Is(err, unix.ENOTSUP) && !errors.Is(err, sysx.ENODATA) {
 		return false, fmt.Errorf("failed to get xattr for %s: %w", p2, err)
 	}
 	return bytes.Equal(c1, c2), nil


### PR DESCRIPTION
commit container image (nerdctl commit) will failed to get xattr in filesystems without xattr support.

```
FATA[0006] failed to export layer: mount callback failed on /xxx/containerd/tmpmounts/containerd-mount1781253780: mount callback failed on /xxx/tmpmounts/containerd-mount4034463149: failed to write compressed diff: failed to create diff tar stream: failed to get xattr for /xxx/containerd/tmpmounts/containerd-mount4034463149/etc: operation not supported: unknown 
```

when LGetxattr syscall return ENOTSUP error, continuity should handle it.