### PR TITLE
ci: declare contents:read on Continuity CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 env:
   GO_VERSION: 1.22.x
 
+permissions:
+  contents: read
+
 jobs:
 
   #


### PR DESCRIPTION
Pins `ci.yml` to `contents: read` at workflow scope. The three jobs (`project`, `tests`, `cross`) only check out the repo, set up Go, and run `make test`, `make root-test`, `make build binaries` across the matrix. No GitHub API write.

Defense-in-depth motivation is [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) on `tj-actions/changed-files`: a compromised third-party action runs inside the existing job context and exfiltrates the workflow `GITHUB_TOKEN` via build logs. The blast radius equals the token's issued scope. Containerd's project-checks action and golangci/setup-go are third-party, so the cap is meaningful here.

Style matches the per-job permissions block in `codeql.yml` (`security-events: write`). YAML validated locally with `yaml.safe_load`.