### PR TITLE
Improve error reporting in `copyIrregular`

### DIFF
--- a/fs/copy_irregular_freebsd.go
+++ b/fs/copy_irregular_freebsd.go
@@ -32,5 +32,10 @@ func copyIrregular(dst string, fi os.FileInfo) error {
 	if fi.Mode()&os.ModeDevice == os.ModeDevice {
 		rDev = st.Rdev
 	}
-	return syscall.Mknod(dst, uint32(st.Mode), rDev)
+
+	if err := syscall.Mknod(dst, uint32(st.Mode), rDev); err != nil {
+		return fmt.Errorf("failed to mknod %q: %w", dst, err)
+	}
+
+	return nil
 }

--- a/fs/copy_irregular_unix.go
+++ b/fs/copy_irregular_unix.go
@@ -34,6 +34,11 @@ func copyIrregular(dst string, fi os.FileInfo) error {
 	if fi.Mode()&os.ModeDevice == os.ModeDevice {
 		rDev = int(st.Rdev)
 	}
+
 	//nolint:unconvert
-	return syscall.Mknod(dst, uint32(st.Mode), rDev)
+	if err := syscall.Mknod(dst, uint32(st.Mode), rDev); err != nil {
+		return fmt.Errorf("failed to mknod %q: %w", dst, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Add filename to error message so it is clear what exactly failed to be copied