### PR TITLE
fs: remove per-file fsync from sparse-aware copyFile

### DIFF
--- a/fs/copy_linux.go
+++ b/fs/copy_linux.go
@@ -135,10 +135,6 @@ func copyFile(target, source string) error {
 		offset = holeStart
 	}
 
-	if err := tgt.Sync(); err != nil {
-		return fmt.Errorf("failed to sync target %s: %w", target, err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
The per-file tgt.Sync() added in a424ba1 causes a 17x performance regression when copying directories with many files. For 50K files of 10KiB each, per-file fsync takes over 1 minute vs 4.4 seconds without it.

This severely impacts container start latency for images using the VOLUME directive, where volumeCopyUp calls fs.CopyDir to populate the mount point.

The previous implementation (io.Copy) never called fsync, and the callers of CopyDir do not require per-file durability — the source data is always available for replay from immutable image layers.

Fixes: https://github.com/containerd/continuity/issues/303