### PR TITLE
fs: make fsync opt-in via CopyFileOpt and CopyDirOpt

### DIFF
--- a/fs/copy.go
+++ b/fs/copy.go
@@ -33,7 +33,9 @@ type XAttrErrorHandler func(dst, src, xattrKey string, err error) error
 type copyDirOpts struct {
 	xeh XAttrErrorHandler
 	// xex contains a set of xattrs to exclude when copying
-	xex map[string]struct{}
+	xex      map[string]struct{}
+	fileSync bool
+	dirSync  bool
 }
 
 type CopyDirOpt func(*copyDirOpts) error
@@ -65,6 +67,34 @@ func WithXAttrExclude(keys ...string) CopyDirOpt {
 		for _, key := range keys {
 			o.xex[key] = struct{}{}
 		}
+		return nil
+	}
+}
+
+// WithCopyFileSync ensures each file copied within CopyDir is fsynced to
+// persistent storage before proceeding to the next file.
+//
+// By default, files are not synced. Versions prior to v0.5.0 never synced;
+// v0.5.0 added unconditional per-file fsync which caused a performance
+// regression.
+func WithCopyFileSync() CopyDirOpt {
+	return func(o *copyDirOpts) error {
+		o.fileSync = true
+		return nil
+	}
+}
+
+// WithCopyDirSync ensures full crash durability during CopyDir.
+// This implies file-level fsync (WithCopyFileSync) and additionally fsyncs
+// each directory after all its entries have been copied.
+//
+// By default, neither files nor directories are synced. Versions prior to
+// v0.5.0 never synced; v0.5.0 added unconditional per-file fsync which
+// caused a performance regression.
+func WithCopyDirSync() CopyDirOpt {
+	return func(o *copyDirOpts) error {
+		o.fileSync = true
+		o.dirSync = true
 		return nil
 	}
 }
@@ -143,7 +173,7 @@ func copyDirectory(dst, src string, inodes map[uint64]string, o *copyDirOpts) er
 				if err := os.Link(link, target); err != nil {
 					return fmt.Errorf("failed to create hard link: %w", err)
 				}
-			} else if err := CopyFile(target, source); err != nil {
+			} else if err := copyFileWithOpts(target, source, o); err != nil {
 				return fmt.Errorf("failed to copy files: %w", err)
 			}
 		case (fileInfo.Mode() & os.ModeSymlink) == os.ModeSymlink:
@@ -185,16 +215,54 @@ func copyDirectory(dst, src string, inodes map[uint64]string, o *copyDirOpts) er
 			return err
 		}
 	}
-	return dr.Err()
+	if err := dr.Err(); err != nil {
+		return err
+	}
+
+	if o.dirSync {
+		if err := syncDirectory(dst); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func copyFileWithOpts(target, source string, o *copyDirOpts) error {
+	if o.fileSync {
+		return CopyFile(target, source, WithFileSync())
+	}
+	return CopyFile(target, source)
+}
+
+type CopyFileOpt func(*copyFileConfig)
+
+type copyFileConfig struct {
+	sync bool
+}
+
+// WithFileSync ensures the copied file is fsynced to persistent
+// storage before returning.
+//
+// By default, files are not synced. Versions prior to v0.5.0 never synced;
+// v0.5.0 added unconditional per-file fsync which caused a performance regression.
+func WithFileSync() CopyFileOpt {
+	return func(c *copyFileConfig) {
+		c.sync = true
+	}
 }
 
 // CopyFile copies the source file to the target.
 // The most efficient means of copying is used for the platform.
-func CopyFile(target, source string) error {
-	return copyFile(target, source)
+func CopyFile(target, source string, opts ...CopyFileOpt) error {
+	var cfg copyFileConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return copyFile(target, source, cfg.sync)
 }
 
-func openAndCopyFile(target, source string) error {
+func openAndCopyFile(target, source string, sync bool) error {
 	src, err := os.Open(source)
 	if err != nil {
 		return fmt.Errorf("failed to open source %s: %w", source, err)
@@ -206,6 +274,13 @@ func openAndCopyFile(target, source string) error {
 	}
 	defer tgt.Close()
 
-	_, err = io.Copy(tgt, src)
-	return err
+	if _, err = io.Copy(tgt, src); err != nil {
+		return err
+	}
+	if sync {
+		if err := tgt.Sync(); err != nil {
+			return fmt.Errorf("failed to sync target %s: %w", target, err)
+		}
+	}
+	return nil
 }

--- a/fs/copy_linux.go
+++ b/fs/copy_linux.go
@@ -34,7 +34,7 @@ const maxCopyChunk = 1 << 30 // 1 GiB
 //
 // If the filesystem does not support SEEK_DATA/SEEK_HOLE, it falls back
 // to a plain io.Copy.
-func copyFile(target, source string) error {
+func copyFile(target, source string, sync bool) error {
 	src, err := os.Open(source)
 	if err != nil {
 		return fmt.Errorf("failed to open source %s: %w", source, err)
@@ -72,7 +72,7 @@ func copyFile(target, source string) error {
 			// Filesystem doesn't support SEEK_DATA/SEEK_HOLE. Fall back to a plain copy.
 			src.Close()
 			tgt.Close()
-			return openAndCopyFile(target, source)
+			return openAndCopyFile(target, source, sync)
 		}
 
 		return fmt.Errorf("failed to seek data in source %s: %w", source, err)
@@ -122,7 +122,7 @@ func copyFile(target, source string) error {
 				if errors.Is(err, syscall.EXDEV) || errors.Is(err, syscall.ENOSYS) || errors.Is(err, syscall.EOPNOTSUPP) {
 					src.Close()
 					tgt.Close()
-					return openAndCopyFile(target, source)
+					return openAndCopyFile(target, source, sync)
 				}
 				return fmt.Errorf("copy_file_range failed: %w", err)
 			}
@@ -133,6 +133,12 @@ func copyFile(target, source string) error {
 		}
 
 		offset = holeStart
+	}
+
+	if sync {
+		if err := tgt.Sync(); err != nil {
+			return fmt.Errorf("failed to sync target %s: %w", target, err)
+		}
 	}
 
 	return nil

--- a/fs/copy_linux_test.go
+++ b/fs/copy_linux_test.go
@@ -128,6 +128,81 @@ func TestCopyFileSparse(t *testing.T) {
 	}
 }
 
+func TestCopyFileSparseWithSync(t *testing.T) {
+	dir := t.TempDir()
+
+	type testCase struct {
+		name  string
+		parts []int64
+	}
+
+	tests := []testCase{
+		{
+			name:  "DataHoleData",
+			parts: []int64{4096, 1024 * 1024, 4096},
+		},
+		{
+			name:  "NoHoles",
+			parts: []int64{64 * 1024},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srcPath := filepath.Join(dir, tc.name+"-sync-src")
+			dstPath := filepath.Join(dir, tc.name+"-sync-dst")
+
+			applier := createSparseFile(tc.name+"-sync-src", 42, 0o644, tc.parts...)
+			if err := applier.Apply(dir); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := CopyFile(dstPath, srcPath, WithFileSync()); err != nil {
+				t.Fatalf("CopyFile with WithFileSync failed: %v", err)
+			}
+
+			// Verify content matches exactly.
+			srcData, err := os.ReadFile(srcPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			dstData, err := os.ReadFile(dstPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(srcData, dstData) {
+				t.Fatal("source and destination file contents differ")
+			}
+
+			// Verify sparseness is preserved.
+			srcStat, err := os.Stat(srcPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			dstStat, err := os.Stat(dstPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			srcBlocks := srcStat.Sys().(*syscall.Stat_t).Blocks
+			dstBlocks := dstStat.Sys().(*syscall.Stat_t).Blocks
+
+			t.Logf("src size=%d blocks=%d, dst size=%d blocks=%d",
+				srcStat.Size(), srcBlocks, dstStat.Size(), dstBlocks)
+
+			if srcStat.Size() != dstStat.Size() {
+				t.Fatalf("size mismatch: src=%d dst=%d", srcStat.Size(), dstStat.Size())
+			}
+
+			maxBlocks := srcBlocks + srcBlocks/10 + 8
+			if dstBlocks > maxBlocks {
+				t.Fatalf("destination is not sparse: src blocks=%d, dst blocks=%d (max allowed=%d)",
+					srcBlocks, dstBlocks, maxBlocks)
+			}
+		})
+	}
+}
+
 func TestCopyReflinkWithXFS(t *testing.T) {
 	testutil.RequiresRoot(t)
 	mnt := t.TempDir()

--- a/fs/copy_nondarwin.go
+++ b/fs/copy_nondarwin.go
@@ -18,4 +18,6 @@
 
 package fs
 
-var copyFile = openAndCopyFile
+func copyFile(target, source string, sync bool) error {
+	return openAndCopyFile(target, source, sync)
+}

--- a/fs/copy_test.go
+++ b/fs/copy_test.go
@@ -124,3 +124,166 @@ func benchmarkLargeCopyFile(b *testing.B, size int64) {
 		os.RemoveAll(copied)
 	}
 }
+
+func TestCopyFileWithSync(t *testing.T) {
+	dir := t.TempDir()
+	src := dir + "/src"
+	dst := dir + "/dst"
+
+	data := []byte("this is a file sync test")
+	if err := os.WriteFile(src, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyFile(dst, src, WithFileSync()); err != nil {
+		t.Fatalf("CopyFile with WithFileSync failed: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("content mismatch: got %q, want %q", got, data)
+	}
+}
+
+func TestCopyFileWithoutSync(t *testing.T) {
+	dir := t.TempDir()
+	src := dir + "/src"
+	dst := dir + "/dst"
+
+	data := []byte("this is a no-sync test")
+	if err := os.WriteFile(src, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyFile(dst, src); err != nil {
+		t.Fatalf("CopyFile without sync failed: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("content mismatch: got %q, want %q", got, data)
+	}
+}
+
+func TestCopyDirWithFileSync(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	apply := fstest.Apply(
+		fstest.CreateDir("/subdir", 0o755),
+		fstest.CreateFile("/subdir/file.txt", []byte("this is a file sync test"), 0o644),
+		fstest.CreateFile("/root.txt", []byte("root file"), 0o644),
+	)
+	if err := apply.Apply(src); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyDir(dst, src, WithCopyFileSync()); err != nil {
+		t.Fatalf("CopyDir with WithCopyFileSync failed: %v", err)
+	}
+
+	if err := fstest.CheckDirectoryEqual(src, dst); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCopyDirWithDirSync(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	apply := fstest.Apply(
+		fstest.CreateDir("/subdir", 0o755),
+		fstest.CreateFile("/subdir/file.txt", []byte("this is a dir sync test"), 0o644),
+		fstest.CreateFile("/root.txt", []byte("root file"), 0o644),
+	)
+	if err := apply.Apply(src); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyDir(dst, src, WithCopyDirSync()); err != nil {
+		t.Fatalf("CopyDir with WithCopyDirSync failed: %v", err)
+	}
+
+	if err := fstest.CheckDirectoryEqual(src, dst); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func BenchmarkCopyFile(b *testing.B) {
+	benchmarkCopyFile(b, false)
+}
+
+func BenchmarkCopyFileWithSync(b *testing.B) {
+	benchmarkCopyFile(b, true)
+}
+
+func benchmarkCopyFile(b *testing.B, sync bool) {
+	b.StopTimer()
+	base := b.TempDir()
+	apply := fstest.Apply(
+		fstest.CreateRandomFile("/benchfile", time.Now().UnixNano(), 10*1024*1024, 0o644),
+	)
+	if err := apply.Apply(base); err != nil {
+		b.Fatal("failed to apply changes:", err)
+	}
+	src := base + "/benchfile"
+
+	var opts []CopyFileOpt
+	if sync {
+		opts = append(opts, WithFileSync())
+	}
+
+	for i := 0; i < b.N; i++ {
+		dst := b.TempDir() + "/dst"
+		b.StartTimer()
+		if err := CopyFile(dst, src, opts...); err != nil {
+			b.Fatal("failed to copy:", err)
+		}
+		b.StopTimer()
+	}
+}
+
+func BenchmarkCopyDir(b *testing.B) {
+	benchmarkCopyDir(b, false)
+}
+
+func BenchmarkCopyDirWithSync(b *testing.B) {
+	benchmarkCopyDir(b, true)
+}
+
+func benchmarkCopyDir(b *testing.B, sync bool) {
+	b.StopTimer()
+	base := b.TempDir()
+
+	appliers := []fstest.Applier{
+		fstest.CreateDir("/manyfiles", 0o755),
+	}
+	for i := 0; i < 500; i++ {
+		appliers = append(appliers,
+			fstest.CreateRandomFile(fmt.Sprintf("/manyfiles/file_%04d", i), int64(i), 4096, 0o644),
+		)
+	}
+	if err := fstest.Apply(appliers...).Apply(base); err != nil {
+		b.Fatal("failed to apply:", err)
+	}
+
+	var opts []CopyDirOpt
+	if sync {
+		opts = append(opts, WithCopyDirSync())
+	}
+
+	for i := 0; i < b.N; i++ {
+		dst := b.TempDir()
+		b.StartTimer()
+		if err := CopyDir(dst, base+"/manyfiles", opts...); err != nil {
+			b.Fatal("failed to copy:", err)
+		}
+		b.StopTimer()
+	}
+}

--- a/fs/sync_unix.go
+++ b/fs/sync_unix.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 /*
    Copyright The containerd Authors.
 
@@ -17,19 +19,18 @@
 package fs
 
 import (
-	"errors"
 	"fmt"
-
-	"golang.org/x/sys/unix"
+	"os"
 )
 
-func copyFile(target, source string, sync bool) error {
-	if err := unix.Clonefile(source, target, unix.CLONE_NOFOLLOW); err != nil {
-		if !errors.Is(err, unix.ENOTSUP) && !errors.Is(err, unix.EXDEV) {
-			return fmt.Errorf("clonefile failed: %w", err)
-		}
-
-		return openAndCopyFile(target, source, sync)
+func syncDirectory(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("failed to open directory for sync %s: %w", dir, err)
+	}
+	defer d.Close()
+	if err := d.Sync(); err != nil {
+		return fmt.Errorf("failed to sync directory %s: %w", dir, err)
 	}
 	return nil
 }

--- a/fs/sync_windows.go
+++ b/fs/sync_windows.go
@@ -16,20 +16,7 @@
 
 package fs
 
-import (
-	"errors"
-	"fmt"
-
-	"golang.org/x/sys/unix"
-)
-
-func copyFile(target, source string, sync bool) error {
-	if err := unix.Clonefile(source, target, unix.CLONE_NOFOLLOW); err != nil {
-		if !errors.Is(err, unix.ENOTSUP) && !errors.Is(err, unix.EXDEV) {
-			return fmt.Errorf("clonefile failed: %w", err)
-		}
-
-		return openAndCopyFile(target, source, sync)
-	}
+// syncDirectory is a no-op on Windows, which does not support fsync on directories.
+func syncDirectory(dir string) error {
 	return nil
 }


### PR DESCRIPTION
Fixes #303

## Problem

The per-file `tgt.Sync()` added in a424ba1 causes significant latency for workloads that copy many files. Most callers of `CopyFile` and `CopyDir` do not require per-file durability, as the source data is typically available for replay.

## Changes
- Add `WithFileSync()` option to `CopyFile` for opt-in per-file fsync
- Add `WithCopyFileSync()` and `WithCopyDirSync()` options to `CopyDir`
- Default behavior is no-fsync, restoring behavior prior to a424ba1
- `WithCopyDirSync()` implies file-level fsync and additionally fsyncs each directory after all entries are copied

The variadic signature for `CopyFile` is backwards-compatible and existing callers require no changes.

## Testing
Added unit tests. Additionally tested by vendoring into containerd (main) and running the blockfile snapshotter, archive, and CRI podsandbox test suites successfully.